### PR TITLE
fix: Corregir tipos de TypeScript en actualizaciÃ³n de servicios

### DIFF
--- a/src/app/api/admin/professionals/[id]/services/[serviceId]/route.ts
+++ b/src/app/api/admin/professionals/[id]/services/[serviceId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { requireAdminApiKey } from '@/lib/auth-helpers';
+import { Prisma, CategoryGroupId } from '@prisma/client';
 
 /**
  * PUT /api/admin/professionals/:professionalId/services/:serviceId
@@ -127,14 +128,7 @@ export async function PUT(
     }
 
     // Construir datos de actualización
-    const updateData: {
-      categoryId?: string;
-      categoryGroup?: string | null;
-      title?: string;
-      description?: string;
-      priceRange?: string;
-      available?: boolean;
-    } = {};
+    const updateData: Prisma.ServiceUncheckedUpdateInput = {};
 
     if (body.categoryId !== undefined) {
       updateData.categoryId = body.categoryId;
@@ -144,8 +138,8 @@ export async function PUT(
           where: { id: body.categoryId },
           select: { groupId: true }
         });
-        if (newCategory) {
-          updateData.categoryGroup = newCategory.groupId;
+        if (newCategory && (newCategory.groupId === 'oficios' || newCategory.groupId === 'profesiones')) {
+          updateData.categoryGroup = newCategory.groupId as CategoryGroupId;
         }
       }
     }


### PR DESCRIPTION
- Usar Prisma.ServiceUncheckedUpdateInput para actualizaciÃ³n de servicios
- Corregir tipo de categoryGroup para usar CategoryGroupId enum
- El build ahora compila correctamente sin errores de tipos

## Qué cambia
- 

## Cómo se probó
- [ ] Unit
- [ ] Integration
- [ ] E2E
Comandos: `npm run test`, `npm run test:e2e`

## Checklist
- [ ] Typecheck / Lint ok
- [ ] Estados vacíos/errores cubiertos
- [ ] Mensajes accesibles (roles/labels)
- [ ] Issue linkeado: #123