### PR TITLE
feat: add v1 API envelopes, rate limits and docs

### DIFF
--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -1,0 +1,52 @@
+# API Versioning & Envelope (v1)
+
+## Context
+Para evitar romper clientes existentes, se agrega una versión `v1` paralela a los endpoints actuales. Los endpoints legacy siguen funcionando sin cambios.
+
+## Endpoints v1 añadidos
+- `POST /api/v1/bug-reports`
+- `GET  /api/v1/categories`
+
+## Envelope estándar
+Todas las respuestas v1 usan:
+```json
+{
+  "success": true,
+  "data": {},
+  "meta": {
+    "requestId": "uuid-or-header"
+  }
+}
+```
+En caso de error:
+```json
+{
+  "success": false,
+  "error": {
+    "code": "validation_error",
+    "message": "Descripción legible",
+    "details": { "...": "opcional" }
+  },
+  "meta": { "requestId": "..." }
+}
+```
+
+## Rate limiting (best effort)
+- In-memory por instancia.
+- `/api/v1/bug-reports`: 20 req / 10 min por IP.
+- `/api/v1/categories`: 60 req / 5 min por IP.
+- Cabeceras: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`.
+
+## Compatibilidad
+- Endpoints legacy **no cambian**.
+- Migrar clientes a `/api/v1/...` para recibir envelope y errores consistentes.
+- Si se necesitan campos adicionales en `meta` (p.ej. paginación), añadir sin romper.
+
+## OpenAPI
+- Especificación v1 en `docs/openapi-v1.yaml`.
+- Servida en `/api/docs` (YAML) y `/api/docs/ui` (Swagger UI) solo en dev/stg. Para producción, habilitar con `ALLOW_API_DOCS=true`.
+
+## Próximos pasos sugeridos
+- Publicar `openapi.yaml` para v1.
+- Añadir `X-Request-Id` generado por el edge/proxy para correlación.
+- Evaluar mover rate limiting a capa shared (Redis/PgBouncer) para entornos serverless.

--- a/docs/CHECKLIST_POST_VERIFICACION.md
+++ b/docs/CHECKLIST_POST_VERIFICACION.md
@@ -1,0 +1,133 @@
+# Checklist Post-Verificación Google Search Console
+
+## ✅ Pasos Inmediatos (Hacer AHORA)
+
+### 1. Enviar Sitemap
+- [ ] Ir a Google Search Console → "Sitemaps"
+- [ ] Ingresar: `sitemap.xml`
+- [ ] Clic en "Enviar"
+- [ ] Verificar que aparezca como "Enviado correctamente"
+
+**URL del sitemap:** `https://ceresenred.ceres.gob.ar/sitemap.xml`
+
+---
+
+### 2. Solicitar Indexación de Páginas Principales
+- [ ] Ir a "Inspección de URL"
+- [ ] Solicitar indexación para: `https://ceresenred.ceres.gob.ar`
+- [ ] Solicitar indexación para: `https://ceresenred.ceres.gob.ar/servicios`
+- [ ] Solicitar indexación para: `https://ceresenred.ceres.gob.ar/categorias`
+- [ ] Solicitar indexación para: `https://ceresenred.ceres.gob.ar/como-funciona`
+
+---
+
+### 3. Verificaciones Técnicas
+- [ ] Verificar sitemap accesible: `https://ceresenred.ceres.gob.ar/sitemap.xml`
+- [ ] Verificar robots.txt accesible: `https://ceresenred.ceres.gob.ar/robots.txt`
+- [ ] Verificar meta tag de verificación en el código fuente de la página principal
+
+---
+
+## 📊 Monitoreo Semanal (Primeras 4 Semanas)
+
+### Semana 1
+- [ ] Revisar "Cobertura" en Search Console
+- [ ] Verificar que no haya errores críticos
+- [ ] Revisar "Rendimiento" (puede estar vacío aún)
+
+### Semana 2
+- [ ] Revisar "Cobertura" - verificar páginas indexadas
+- [ ] Revisar "Rendimiento" - verificar primeras impresiones
+- [ ] Revisar "Mejoras" - verificar problemas
+
+### Semana 3
+- [ ] Revisar progreso de indexación
+- [ ] Verificar structured data con: https://search.google.com/test/rich-results
+- [ ] Revisar errores y advertencias
+
+### Semana 4
+- [ ] Evaluar progreso general
+- [ ] Revisar métricas de rendimiento
+- [ ] Planificar mejoras si es necesario
+
+---
+
+## 🔍 Verificaciones Adicionales
+
+### Structured Data
+- [ ] Probar URL de profesional en: https://search.google.com/test/rich-results
+- [ ] Verificar que no haya errores en JSON-LD
+- [ ] Verificar que aparezcan rich snippets
+
+### Open Graph
+- [ ] Probar URL principal en: https://developers.facebook.com/tools/debug/
+- [ ] Verificar que se muestre imagen, título y descripción correctamente
+
+### Mobile Usability
+- [ ] Revisar "Mejoras" → "Usabilidad móvil" en Search Console
+- [ ] Verificar que no haya problemas de mobile
+
+---
+
+## 📈 Métricas a Monitorear
+
+### Cobertura (Indexación)
+- Páginas válidas indexadas
+- Errores de indexación
+- Advertencias
+
+### Rendimiento (Búsquedas)
+- Impresiones (cuántas veces aparece tu sitio)
+- Clics (cuántas veces hacen clic)
+- CTR (Click-Through Rate)
+- Posición promedio
+
+### Mejoras
+- Errores de structured data
+- Problemas de mobile usability
+- Core Web Vitals
+
+---
+
+## ⏱️ Tiempos Esperados
+
+| Acción | Tiempo |
+|--------|--------|
+| Procesamiento del sitemap | 1-7 días |
+| Primera indexación | 1-4 semanas |
+| Indexación completa | 2-8 semanas |
+| Aparición en búsquedas | 2-6 semanas |
+
+---
+
+## 🚨 Problemas Comunes
+
+### "Sitemap no se puede leer"
+- Verificar que `/sitemap.xml` sea accesible públicamente
+- Verificar que el XML sea válido
+- Verificar que no haya errores en la generación
+
+### "Páginas no se indexan"
+- Verificar que las páginas tengan contenido único
+- Verificar que no haya contenido duplicado
+- Verificar que las páginas sean accesibles sin autenticación
+- Solicitar indexación manualmente
+
+### "Googlebot no puede acceder"
+- Verificar que no haya firewall bloqueando
+- Verificar que el servidor no bloquee user-agents de Google
+- Verificar que no haya rate limiting muy restrictivo
+
+---
+
+## 📝 Notas
+
+- **Paciencia:** La indexación toma tiempo. No esperes resultados inmediatos.
+- **Consistencia:** Google indexa mejor sitios que se actualizan regularmente.
+- **Calidad:** Mejor tener pocas páginas bien optimizadas que muchas con contenido pobre.
+- **Monitoreo:** Revisa Search Console semanalmente al principio.
+
+---
+
+**Fecha de creación:** Enero 2025  
+**Última actualización:** Enero 2025

--- a/docs/openapi-v1.yaml
+++ b/docs/openapi-v1.yaml
@@ -1,0 +1,641 @@
+openapi: 3.1.0
+info:
+  title: CERES API
+  description: Versioned endpoints (v1) with consistent envelopes.
+  version: "1.0.0"
+servers:
+  - url: https://{host}
+    variables:
+      host:
+        default: api.ceres.local
+paths:
+  /api/v1/bug-reports:
+    post:
+      summary: Reportar un bug
+      tags: [bug-reports]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title, description]
+              properties:
+                title:
+                  type: string
+                description:
+                  type: string
+                severity:
+                  type: string
+                  enum: [low, medium, high, critical]
+                  default: medium
+                userEmail:
+                  type: string
+                  format: email
+                context:
+                  type: object
+      responses:
+        "201":
+          description: Bug creado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiSuccessBug"
+        "400":
+          description: Error de validación
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+        "429":
+          description: Rate limit excedido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+  /api/v1/categories:
+    get:
+      summary: Listar categorías, áreas y subcategorías
+      tags: [categories]
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiSuccessCategories"
+        "429":
+          description: Rate limit excedido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+
+  /api/v1/auth/verify:
+    post:
+      summary: Verificar cuenta por token
+      tags: [auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token, email]
+              properties:
+                token: { type: string }
+                email: { type: string, format: email }
+      responses:
+        "200":
+          description: Cuenta verificada
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiSuccessMessage"
+        "400":
+          description: Token inválido o datos incompletos
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+        "404":
+          description: Usuario no encontrado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+        "429":
+          description: Rate limit excedido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+
+  /api/v1/auth/password/reset:
+    post:
+      summary: Resetear contraseña mediante token
+      tags: [auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token, password]
+              properties:
+                token: { type: string }
+                password: { type: string, minLength: 8 }
+      responses:
+        "200":
+          description: Contraseña actualizada
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiSuccessMessage"
+        "400":
+          description: Payload inválido o token inválido/expirado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+        "429":
+          description: Rate limit excedido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+
+  /api/v1/auth/register:
+    post:
+      summary: Registro de usuario (con creación opcional de perfil profesional)
+      tags: [auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password, firstName, lastName]
+              properties:
+                email: { type: string, format: email }
+                password: { type: string, minLength: 8 }
+                firstName: { type: string }
+                lastName: { type: string }
+                phone: { type: string }
+                birthDate: { type: string, format: date }
+                location: { type: string }
+                whatsapp: { type: string }
+                instagram: { type: string }
+                facebook: { type: string }
+                linkedin: { type: string }
+                website: { type: string }
+                portfolio: { type: string }
+                cv: { type: string }
+                picture: { type: string }
+                bio: { type: string }
+                experienceYears: { type: integer }
+                professionalGroup: { type: string, enum: [oficios, profesiones] }
+                serviceLocations:
+                  type: array
+                  items: { type: string }
+                hasPhysicalStore: { type: boolean }
+                physicalStoreAddress: { type: string }
+                services:
+                  type: array
+                  items:
+                    type: object
+                    required: [categoryId, title, description]
+                    properties:
+                      categoryId: { type: string }
+                      title: { type: string }
+                      description: { type: string }
+      responses:
+        "201":
+          description: Creado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiSuccessRegister"
+        "400":
+          description: Datos inválidos o usuario existente
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+        "429":
+          description: Rate limit excedido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+
+  /api/v1/auth/complete-profile:
+    post:
+      summary: Completar perfil profesional de un usuario existente
+      tags: [auth]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [phone, location, bio, professionalGroup, services]
+              properties:
+                phone: { type: string }
+                location: { type: string }
+                bio: { type: string }
+                experienceYears: { type: integer }
+                professionalGroup: { type: string, enum: [oficios, profesiones] }
+                serviceLocations:
+                  type: array
+                  items: { type: string }
+                services:
+                  type: array
+                  items:
+                    type: object
+                    required: [categoryId, description]
+                    properties:
+                      categoryId: { type: string }
+                      title: { type: string }
+                      description: { type: string }
+      responses:
+        "200":
+          description: Perfil creado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiSuccessProfessional"
+        "400":
+          description: Datos inválidos
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+        "401":
+          description: No autorizado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+        "404":
+          description: Usuario no encontrado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+        "429":
+          description: Rate limit excedido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+
+components:
+  schemas:
+    ApiMeta:
+      type: object
+      properties:
+        requestId:
+          type: string
+        pagination:
+          type: object
+          properties:
+            page: { type: integer }
+            pageSize: { type: integer }
+            total: { type: integer }
+    ApiError:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        details:
+          description: Datos opcionales del error.
+    ApiFailure:
+      type: object
+      required: [success, error]
+      properties:
+        success:
+          type: boolean
+          enum: [false]
+        error:
+          $ref: "#/components/schemas/ApiError"
+        meta:
+          $ref: "#/components/schemas/ApiMeta"
+    ApiSuccessBug:
+      type: object
+      required: [success, data]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          $ref: "#/components/schemas/BugReport"
+        meta:
+          $ref: "#/components/schemas/ApiMeta"
+    ApiSuccessCategories:
+      type: object
+      required: [success, data]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          type: object
+          properties:
+            areas:
+              type: array
+              items:
+                $ref: "#/components/schemas/Area"
+            subcategoriesOficios:
+              type: array
+              items:
+                $ref: "#/components/schemas/Subcategory"
+            subcategoriesProfesiones:
+              type: array
+              items:
+                $ref: "#/components/schemas/Subcategory"
+        meta:
+          $ref: "#/components/schemas/ApiMeta"
+    ApiSuccessProfessionals:
+      type: object
+      required: [success, data]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProfessionalSummary"
+        meta:
+          $ref: "#/components/schemas/ApiMeta"
+    ApiSuccessServices:
+      type: object
+      required: [success, data]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ServiceSummary"
+        meta:
+          $ref: "#/components/schemas/ApiMeta"
+    ApiSuccessService:
+      type: object
+      required: [success, data]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          $ref: "#/components/schemas/ServiceSummary"
+        meta:
+          $ref: "#/components/schemas/ApiMeta"
+    ApiSuccessRegister:
+      type: object
+      required: [success, data]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          type: object
+          properties:
+            message: { type: string }
+            user:
+              type: object
+            professional:
+              type: object
+            devVerifyUrl: { type: string }
+        meta:
+          $ref: "#/components/schemas/ApiMeta"
+    ApiSuccessProfessional:
+      type: object
+      required: [success, data]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          type: object
+        meta:
+          $ref: "#/components/schemas/ApiMeta"
+    ApiSuccessMessage:
+      type: object
+      required: [success, data]
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          type: object
+          properties:
+            message:
+              type: string
+        meta:
+          $ref: "#/components/schemas/ApiMeta"
+    BugReport:
+      type: object
+      properties:
+        id: { type: string }
+        title: { type: string }
+        description: { type: string }
+        severity: { type: string }
+        status: { type: string }
+        userEmail: { type: string, nullable: true }
+        userId: { type: string, nullable: true }
+        context: { type: object, nullable: true }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time, nullable: true }
+    Area:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        slug: { type: string }
+        group: { type: string }
+        image: { type: string, nullable: true }
+        description: { type: string, nullable: true }
+        active: { type: boolean }
+        subcategoryCount: { type: integer }
+        professionalCount: { type: integer }
+    Subcategory:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        slug: { type: string }
+        group: { type: string }
+        areaId: { type: string, nullable: true }
+        areaSlug: { type: string, nullable: true }
+        image: { type: string, nullable: true }
+        description: { type: string, nullable: true }
+        active: { type: boolean }
+        professionalCount: { type: integer }
+    ProfessionalSummary:
+      type: object
+      properties:
+        id: { type: string }
+        user:
+          type: object
+          properties:
+            name: { type: string }
+        bio: { type: string }
+        verified: { type: boolean }
+        primaryCategory:
+          type: object
+          properties:
+            name: { type: string, nullable: true }
+        location: { type: string, nullable: true }
+        rating: { type: number }
+        reviewCount: { type: integer }
+        ProfilePicture: { type: string, nullable: true }
+        whatsapp: { type: string, nullable: true }
+        phone: { type: string, nullable: true }
+        serviceLocations:
+          type: array
+          items: { type: string }
+    ServiceSummary:
+      type: object
+      properties:
+        id: { type: string }
+        title: { type: string }
+        description: { type: string }
+        priceRange: { type: string }
+        category:
+          type: object
+          properties:
+            name: { type: string }
+        professional:
+          type: object
+          properties:
+            id: { type: string }
+            location: { type: string, nullable: true }
+            whatsapp: { type: string, nullable: true }
+            phone: { type: string, nullable: true }
+            user:
+              type: object
+              properties:
+                name: { type: string }
+                location: { type: string, nullable: true }
+            rating: { type: number }
+            reviewCount: { type: integer }
+            verified: { type: boolean }
+            ProfilePicture: { type: string, nullable: true }
+  /api/v1/professionals:
+    get:
+      summary: Listar profesionales activos con filtros
+      tags: [professionals]
+      parameters:
+        - in: query
+          name: q
+          schema: { type: string }
+          description: Búsqueda por bio/nombre/servicios.
+        - in: query
+          name: categoria
+          schema: { type: string }
+          description: Slug de subcategoría.
+        - in: query
+          name: grupo
+          schema:
+            type: string
+            enum: [oficios, profesiones]
+        - in: query
+          name: location
+          schema: { type: string }
+        - in: query
+          name: page
+          schema: { type: integer, minimum: 1, default: 1 }
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 50, default: 12 }
+        - in: query
+          name: sortBy
+          schema:
+            type: string
+            enum: [name, rating, recent]
+            default: recent
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiSuccessProfessionals"
+        "429":
+          description: Rate limit excedido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+
+  /api/v1/services:
+    get:
+      summary: Listar servicios disponibles
+      tags: [services]
+      parameters:
+        - in: query
+          name: q
+          schema: { type: string }
+        - in: query
+          name: grupo
+          schema: { type: string, enum: [oficios, profesiones] }
+        - in: query
+          name: categoria
+          schema: { type: string }
+        - in: query
+          name: subcategoria
+          schema: { type: string }
+        - in: query
+          name: location
+          schema: { type: string }
+        - in: query
+          name: page
+          schema: { type: integer, minimum: 1, default: 1 }
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 50, default: 20 }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiSuccessServices"
+        "429":
+          description: Rate limit excedido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+    post:
+      summary: Crear servicio (requiere sesión)
+      tags: [services]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [title, description, categorySlug]
+              properties:
+                title: { type: string }
+                description: { type: string }
+                categorySlug: { type: string }
+                priceRange: { type: string }
+      responses:
+        "201":
+          description: Creado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiSuccessService"
+        "400":
+          description: Body inválido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+        "401":
+          description: No autorizado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+        "404":
+          description: Profesional o categoría no encontrada
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"
+        "429":
+          description: Rate limit excedido
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiFailure"

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const requestId =
+    request.headers.get('x-request-id') ||
+    request.headers.get('x-cf-ray') ||
+    crypto.randomUUID();
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-request-id', requestId);
+
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+
+  response.headers.set('x-request-id', requestId);
+
+  return response;
+}
+
+export const config = {
+  matcher: ['/api/:path*'],
+};

--- a/prisma/migrations/20260202122956_add_fk_indexes/migration.sql
+++ b/prisma/migrations/20260202122956_add_fk_indexes/migration.sql
@@ -1,0 +1,1 @@
+-- This is an empty migration.

--- a/src/app/api/auth/options.ts
+++ b/src/app/api/auth/options.ts
@@ -125,7 +125,6 @@ export const authOptions: AuthOptions = {
                         return false
                     }
 
-                    console.log('OAuth signIn iniciado para:', email, 'provider:', account.provider)
 
                     // Buscar usuario existente
                     let dbUser = await prisma.user.findUnique({
@@ -133,7 +132,6 @@ export const authOptions: AuthOptions = {
                     })
 
                     if (dbUser) {
-                        console.log('Usuario existente encontrado:', dbUser.id)
                         
                         // Verificar si ya tiene esta cuenta OAuth vinculada
                         try {
@@ -147,7 +145,6 @@ export const authOptions: AuthOptions = {
                             })
 
                             if (!existingAccount) {
-                                console.log('Vinculando nueva cuenta OAuth')
                                 // Vincular nueva cuenta OAuth al usuario existente
                                 await prisma.account.create({
                                     data: {
@@ -164,9 +161,7 @@ export const authOptions: AuthOptions = {
                                         session_state: account.session_state as string | null,
                                     }
                                 })
-                            } else {
-                                console.log('Cuenta OAuth ya existe')
-                            }
+                            } 
                         } catch (accountError) {
                             console.error('Error al manejar cuenta OAuth:', accountError)
                             // Continuar aunque falle la vinculación de cuenta
@@ -187,7 +182,6 @@ export const authOptions: AuthOptions = {
                             }
                             
                             if (Object.keys(updateData).length > 0) {
-                                console.log('Actualizando usuario:', updateData)
                                 await prisma.user.update({
                                     where: { id: dbUser.id },
                                     data: updateData
@@ -198,7 +192,6 @@ export const authOptions: AuthOptions = {
                             // Continuar aunque falle la actualización
                         }
                     } else {
-                        console.log('Creando nuevo usuario OAuth')
                         // Usuario no existe - crear nuevo usuario y cuenta OAuth
                         const nameParts = (user.name || '').split(' ')
                         const firstName = nameParts[0] || 'Usuario'
@@ -230,10 +223,8 @@ export const authOptions: AuthOptions = {
                                 }
                             }
                         })
-                        console.log('Usuario creado:', dbUser.id)
                     }
 
-                    console.log('OAuth signIn completado exitosamente')
                     return true
                 } catch (error) {
                     console.error('Error en signIn OAuth:', error)

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -3,117 +3,109 @@ import { prisma } from '@/lib/prisma';
 
 export async function GET() {
   try {
-    // Obtener áreas (solo oficios, sin padre)
-    const areas = await prisma.category.findMany({
-      where: { 
-        groupId: 'oficios', 
-        parentCategoryId: null,
-        active: true
-      },
-      include: {
-        _count: { 
-          select: { 
-            children: true
-          } 
-        }
-      },
-      orderBy: { name: 'asc' }
-    });
-
-    // Subcategorías de oficios (con padre)
-    const subcatOficios = await prisma.category.findMany({
-      where: { 
-        groupId: 'oficios', 
-        parentCategoryId: { not: null },
-        active: true
-      },
-      include: {
-        parent: { select: { id: true, name: true, slug: true } }
-      },
-      orderBy: { name: 'asc' }
-    });
-
-    // Subcategorías de profesiones (sin padre)
-    const subcatProfesiones = await prisma.category.findMany({
-      where: { 
-        groupId: 'profesiones',
-        active: true
-      },
-      orderBy: { name: 'asc' }
-    });
-
-    // Calcular conteos de servicios con profesionales activos para cada subcategoría
-    const subcatOficiosWithCount = await Promise.all(
-      subcatOficios.map(async (sub) => {
-        const count = await prisma.service.count({
-          where: {
-            categoryId: sub.id,
-            professional: {
-              status: 'active'
-            }
-          }
-        });
-        return {
-          id: sub.id,
-          name: sub.name,
-          slug: sub.slug,
-          group: sub.groupId,
-          areaId: sub.parentCategoryId,
-          areaSlug: sub.parent?.slug,
-          image: sub.backgroundUrl,
-          description: sub.description,
-          active: sub.active,
-          professionalCount: count,
-        };
+    const [areas, subcatOficios, subcatProfesiones, counts, childrenCount] = await Promise.all([
+      prisma.category.findMany({
+        where: { 
+          groupId: 'oficios', 
+          parentCategoryId: null,
+          active: true
+        },
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          groupId: true,
+          backgroundUrl: true,
+          description: true,
+          active: true,
+        },
+        orderBy: { name: 'asc' }
+      }),
+      prisma.category.findMany({
+        where: { 
+          groupId: 'oficios', 
+          parentCategoryId: { not: null },
+          active: true
+        },
+        include: {
+          parent: { select: { id: true, name: true, slug: true } }
+        },
+        orderBy: { name: 'asc' }
+      }),
+      prisma.category.findMany({
+        where: { 
+          groupId: 'profesiones',
+          active: true
+        },
+        orderBy: { name: 'asc' }
+      }),
+      prisma.service.groupBy({
+        by: ['categoryId'],
+        _count: { categoryId: true },
+        where: { professional: { status: 'active' } }
+      }),
+      prisma.category.groupBy({
+        by: ['parentCategoryId'],
+        _count: { parentCategoryId: true },
+        where: { groupId: 'oficios', parentCategoryId: { not: null }, active: true }
       })
-    );
+    ]);
 
-    const subcatProfesionesWithCount = await Promise.all(
-      subcatProfesiones.map(async (sub) => {
-        const count = await prisma.service.count({
-          where: {
-            categoryId: sub.id,
-            professional: {
-              status: 'active'
-            }
-          }
-        });
-        return {
-          id: sub.id,
-          name: sub.name,
-          slug: sub.slug,
-          group: sub.groupId,
-          areaId: null,
-          areaSlug: null,
-          image: sub.backgroundUrl,
-          description: sub.description,
-          active: sub.active,
-          professionalCount: count,
-        };
-      })
-    );
+    const serviceCountMap = new Map<string, number>();
+    counts.forEach((c) => serviceCountMap.set(c.categoryId, c._count.categoryId));
+
+    const childrenCountMap = new Map<string, number>();
+    childrenCount.forEach((c) => {
+      if (c.parentCategoryId) {
+        childrenCountMap.set(c.parentCategoryId, c._count.parentCategoryId);
+      }
+    });
+
+    const subcatOficiosWithCount = subcatOficios.map((sub) => ({
+      id: sub.id,
+      name: sub.name,
+      slug: sub.slug,
+      group: sub.groupId,
+      areaId: sub.parentCategoryId,
+      areaSlug: sub.parent?.slug,
+      image: sub.backgroundUrl,
+      description: sub.description,
+      active: sub.active,
+      professionalCount: serviceCountMap.get(sub.id) || 0,
+    }));
+
+    const subcatProfesionesWithCount = subcatProfesiones.map((sub) => ({
+      id: sub.id,
+      name: sub.name,
+      slug: sub.slug,
+      group: sub.groupId,
+      areaId: null,
+      areaSlug: null,
+      image: sub.backgroundUrl,
+      description: sub.description,
+      active: sub.active,
+      professionalCount: serviceCountMap.get(sub.id) || 0,
+    }));
 
     const data = {
-      areas: areas.map(area => ({
-        id: area.id,
-        name: area.name,
-        slug: area.slug,
-        group: area.groupId,
-        image: area.backgroundUrl,
-        description: area.description,
-        active: area.active,
-        subcategoryCount: area._count.children,
-        professionalCount: 0, // Se calculará sumando las subcategorías
-      })),
+      areas: areas.map(area => {
+        const subcats = subcatOficiosWithCount.filter(sub => sub.areaSlug === area.slug);
+        const professionalCount = subcats.reduce((sum, sub) => sum + sub.professionalCount, 0);
+        return {
+          id: area.id,
+          name: area.name,
+          slug: area.slug,
+          group: area.groupId,
+          image: area.backgroundUrl,
+          description: area.description,
+          active: area.active,
+          subcategoryCount: childrenCountMap.get(area.id) || 0,
+          professionalCount,
+        };
+      }),
       subcategoriesOficios: subcatOficiosWithCount,
       subcategoriesProfesiones: subcatProfesionesWithCount,
     };
-
-    // Calcular contadores de profesionales por área
-    data.areas.forEach(area => {
-      const subcats = data.subcategoriesOficios.filter(sub => sub.areaSlug === area.slug);
-      area.professionalCount = subcats.reduce((sum, sub) => sum + sub.professionalCount, 0);
-    });
 
     return NextResponse.json({ success: true, data });
   } catch (error) {

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Expose OpenAPI only in non-production to avoid leaking details.
+const ALLOW_IN_PROD = process.env.ALLOW_API_DOCS === 'true';
+
+export async function GET() {
+  if (process.env.NODE_ENV === 'production' && !ALLOW_IN_PROD) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const filePath = path.join(process.cwd(), 'docs', 'openapi-v1.yaml');
+  const content = fs.readFileSync(filePath, 'utf8');
+
+  return new NextResponse(content, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/yaml',
+      'Cache-Control': 'no-cache',
+    },
+  });
+}

--- a/src/app/api/docs/ui/route.ts
+++ b/src/app/api/docs/ui/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+
+const ALLOW_IN_PROD = process.env.ALLOW_API_DOCS === 'true';
+const openApiUrl = process.env.NEXT_PUBLIC_OPENAPI_URL || '/api/docs';
+
+export async function GET() {
+  if (process.env.NODE_ENV === 'production' && !ALLOW_IN_PROD) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const html = /* html */ `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>CERES API Docs</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+    <style>
+      body { margin: 0; background: #0b1021; }
+      #swagger-ui { max-width: 1200px; margin: 0 auto; padding: 16px; }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script>
+      window.onload = () => {
+        SwaggerUIBundle({
+          url: '${openApiUrl}',
+          dom_id: '#swagger-ui',
+          presets: [SwaggerUIBundle.presets.apis],
+          layout: "BaseLayout",
+          deepLinking: true,
+        });
+      };
+    </script>
+  </body>
+</html>`;
+
+  return new NextResponse(html, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/src/app/api/professional/me/route.ts
+++ b/src/app/api/professional/me/route.ts
@@ -8,7 +8,6 @@ export async function GET() {
   try {
     const session = await getServerSession(authOptions);
     
-    console.log('Session en /api/professional/me:', session);
     
     if (!session?.user?.id) {
       return NextResponse.json({ 
@@ -68,7 +67,6 @@ export async function GET() {
       },
     });
 
-    console.log('Professional encontrado:', professional);
 
     if (!professional) {
       return NextResponse.json({ 

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -12,14 +12,7 @@ export async function POST(request: NextRequest) {
     const file: File | null = data.get('file') as unknown as File;
     const typeHint = data.get('type') as string | null; // 'image' | 'cv' opcional
 
-    // Log para debugging
-    console.log('[upload] Request recibido:', {
-      hasFile: !!file,
-      fileName: file?.name,
-      fileType: file?.type,
-      fileSize: file?.size,
-      typeHint,
-    });
+  
 
     if (!file) {
       console.error('[upload] Error: No se recibió ningún archivo');
@@ -60,7 +53,6 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: validation.error }, { status: 400 });
     }
 
-    console.log('[upload] Validación exitosa, procesando archivo...');
 
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);

--- a/src/app/api/v1/auth/complete-profile/route.ts
+++ b/src/app/api/v1/auth/complete-profile/route.ts
@@ -1,0 +1,171 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '../../../auth/options';
+import { prisma } from '@/lib/prisma';
+import { normalizeWhatsAppNumber } from '@/lib/whatsapp-normalize';
+import { ok, fail, requestMeta } from '@/lib/api-response';
+import { rateLimit, rateLimitHeaders } from '@/lib/rate-limit-memory';
+
+const RL_LIMIT = 30;
+const RL_WINDOW = 10 * 60 * 1000; // 10 min
+
+function clientIp(req: NextRequest) {
+  return (
+    req.headers.get('x-real-ip') ||
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const metaBase = requestMeta(request);
+  const rl = rateLimit(`complete-profile:${clientIp(request)}`, RL_LIMIT, RL_WINDOW);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      fail('rate_limited', 'Demasiadas solicitudes. Intenta más tarde.', undefined, metaBase),
+      { status: 429, headers: rateLimitHeaders(rl) }
+    );
+  }
+
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.email) {
+      return NextResponse.json(fail('unauthorized', 'No autorizado', undefined, metaBase), {
+        status: 401,
+        headers: rateLimitHeaders(rl),
+      });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { email: session.user.email },
+      include: { professional: true },
+    });
+
+    if (!user) {
+      return NextResponse.json(fail('not_found', 'Usuario no encontrado', undefined, metaBase), {
+        status: 404,
+        headers: rateLimitHeaders(rl),
+      });
+    }
+
+    if (user.professional) {
+      return NextResponse.json(fail('conflict', 'Ya tienes un perfil profesional', undefined, metaBase), {
+        status: 400,
+        headers: rateLimitHeaders(rl),
+      });
+    }
+
+    const body = await request.json();
+    const { phone, location, bio, experienceYears, professionalGroup, serviceLocations, services } = body;
+
+    if (!phone || !location || !bio || !professionalGroup) {
+      return NextResponse.json(fail('validation_error', 'Faltan campos requeridos', undefined, metaBase), {
+        status: 400,
+        headers: rateLimitHeaders(rl),
+      });
+    }
+
+    if (!services || services.length === 0) {
+      return NextResponse.json(fail('validation_error', 'Debes agregar al menos un servicio', undefined, metaBase), {
+        status: 400,
+        headers: rateLimitHeaders(rl),
+      });
+    }
+
+    const result = await prisma.$transaction(async (tx) => {
+      const categoryGroupRecord = await tx.categoryGroup.upsert({
+        where: { id: professionalGroup },
+        update: {},
+        create: {
+          id: professionalGroup,
+          name: professionalGroup === 'oficios' ? 'Oficios' : 'Profesiones',
+          slug: professionalGroup,
+        },
+      });
+
+      await tx.user.update({
+        where: { id: user.id },
+        data: {
+          phone,
+          location,
+          role: 'professional',
+        },
+      });
+
+      const professional = await tx.professional.create({
+        data: {
+          userId: user.id,
+          bio,
+          experienceYears: experienceYears || 0,
+          professionalGroup,
+          location,
+          serviceLocations: serviceLocations || [location],
+          whatsapp: normalizeWhatsAppNumber(phone) || null,
+          status: 'pending',
+          verified: false,
+        },
+      });
+
+      for (const service of services) {
+        const category = await tx.category.findUnique({
+          where: { slug: service.categoryId },
+        });
+
+        if (category) {
+          await tx.service.create({
+            data: {
+              professionalId: professional.id,
+              categoryId: category.id,
+              categoryGroup: professionalGroup,
+              title: service.title || category.name,
+              description: service.description,
+              available: true,
+            },
+          });
+        } else {
+          const fallbackName = String(service.categoryId)
+            .replace(/-/g, ' ')
+            .replace(/\b\w/g, (m: string) => m.toUpperCase());
+
+          const newCategory = await tx.category.create({
+            data: {
+              name: fallbackName,
+              description: '',
+              slug: service.categoryId,
+              active: true,
+              groupId: categoryGroupRecord.id,
+            },
+          });
+
+          await tx.service.create({
+            data: {
+              professionalId: professional.id,
+              categoryId: newCategory.id,
+              categoryGroup: professionalGroup,
+              title: service.title || newCategory.name,
+              description: service.description,
+              available: true,
+            },
+          });
+        }
+      }
+
+      return professional;
+    });
+
+    return NextResponse.json(ok(result, metaBase), { headers: rateLimitHeaders(rl) });
+  } catch (error) {
+    console.error('Error en complete-profile v1:', error);
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    const isValidation =
+      message.toLowerCase().includes('required') ||
+      message.toLowerCase().includes('invalid') ||
+      message.toLowerCase().includes('not found');
+
+    return NextResponse.json(
+      fail(isValidation ? 'validation_error' : 'server_error', message, undefined, metaBase),
+      { status: isValidation ? 400 : 500, headers: rateLimitHeaders(rl) }
+    );
+  }
+}

--- a/src/app/api/v1/auth/password/reset/route.ts
+++ b/src/app/api/v1/auth/password/reset/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from 'next/server';
+import bcrypt from 'bcryptjs';
+import { prisma } from '@/lib/prisma';
+import { ok, fail, requestMeta } from '@/lib/api-response';
+import { rateLimit, rateLimitHeaders } from '@/lib/rate-limit-memory';
+
+const LIMIT = 20;
+const WINDOW_MS = 10 * 60 * 1000; // 10 min
+
+function clientIp(req: NextRequest) {
+  return (
+    req.headers.get('x-real-ip') ||
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const meta = requestMeta(request);
+  const rl = rateLimit(`password-reset:${clientIp(request)}`, LIMIT, WINDOW_MS);
+
+  if (!rl.allowed) {
+    return NextResponse.json(
+      fail('rate_limited', 'Demasiadas solicitudes. Intenta más tarde.', undefined, meta),
+      { status: 429, headers: rateLimitHeaders(rl) }
+    );
+  }
+
+  try {
+    const { token, password } = (await request.json()) as {
+      token?: string;
+      password?: string;
+    };
+
+    if (!token || typeof token !== 'string' || !password || typeof password !== 'string') {
+      return NextResponse.json(
+        fail('invalid_payload', 'Payload inválido', undefined, meta),
+        { status: 400, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    if (password.length < 8) {
+      return NextResponse.json(
+        fail('weak_password', 'La contraseña debe tener al menos 8 caracteres.', undefined, meta),
+        { status: 400, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    const verification = await prisma.verificationToken.findUnique({
+      where: { token },
+      include: { user: true },
+    });
+
+    if (!verification) {
+      return NextResponse.json(
+        fail('invalid_token', 'El enlace no es válido o ya fue usado.', undefined, meta),
+        { status: 400, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    if (verification.expiresAt < new Date()) {
+      return NextResponse.json(
+        fail('expired_token', 'El enlace de recuperación expiró. Pedí uno nuevo.', undefined, meta),
+        { status: 400, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: verification.userId },
+    });
+
+    if (!user) {
+      return NextResponse.json(
+        fail('user_not_found', 'Usuario no encontrado.', undefined, meta),
+        { status: 400, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    if (!user.password) {
+      return NextResponse.json(
+        fail('oauth_only', 'Esta cuenta usa inicio de sesión social. Usa ese método.', undefined, meta),
+        { status: 400, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    const hashed = await bcrypt.hash(password, 10);
+
+    await prisma.$transaction([
+      prisma.user.update({
+        where: { id: user.id },
+        data: {
+          password: hashed,
+          updatedAt: new Date(),
+        },
+      }),
+      prisma.verificationToken.delete({
+        where: { id: verification.id },
+      }),
+    ]);
+
+    return NextResponse.json(ok({ success: true }, meta), {
+      headers: rateLimitHeaders(rl),
+    });
+  } catch (error) {
+    console.error('Error en reset password (v1):', error);
+    return NextResponse.json(
+      fail('server_error', 'Error al resetear contraseña', undefined, meta),
+      { status: 500, headers: rateLimitHeaders(rl) }
+    );
+  }
+}

--- a/src/app/api/v1/auth/register/route.ts
+++ b/src/app/api/v1/auth/register/route.ts
@@ -7,41 +7,63 @@ import { generateRandomToken } from '@/lib/utils';
 import { enqueueEmailVerify } from '@/jobs/email.producer';
 import { enqueueSlackAlert } from '@/jobs/slack.producer';
 import { normalizeWhatsAppNumber } from '@/lib/whatsapp-normalize';
+import { ok, fail, requestMeta } from '@/lib/api-response';
+import { rateLimit, rateLimitHeaders } from '@/lib/rate-limit-memory';
 
+const RL_LIMIT = 40;
+const RL_WINDOW = 10 * 60 * 1000; // 10 min
+
+function clientIp(req: NextRequest) {
+  return (
+    req.headers.get('x-real-ip') ||
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  );
+}
+
+interface ServiceFormInput {
+  categoryId: string;
+  title: string;
+  description: string;
+}
+
+interface RegisterRequestPayload {
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+  phone?: string;
+  birthDate?: string;
+  location?: string;
+  whatsapp?: string;
+  instagram?: string;
+  facebook?: string;
+  linkedin?: string;
+  website?: string;
+  portfolio?: string;
+  cv?: string;
+  picture?: string;
+  bio?: string;
+  experienceYears?: number;
+  professionalGroup?: CategoryGroup;
+  serviceLocations?: string[];
+  hasPhysicalStore?: boolean;
+  physicalStoreAddress?: string;
+  services?: ServiceFormInput[];
+}
 
 export async function POST(request: NextRequest) {
+  const metaBase = requestMeta(request);
+  const rl = rateLimit(`auth-register:${clientIp(request)}`, RL_LIMIT, RL_WINDOW);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      fail('rate_limited', 'Demasiadas solicitudes. Intenta más tarde.', undefined, metaBase),
+      { status: 429, headers: rateLimitHeaders(rl) }
+    );
+  }
+
   try {
-    interface ServiceFormInput {
-      categoryId: string;
-      title: string;
-      description: string;
-    }
-
-    interface RegisterRequestPayload {
-      email: string;
-      password: string;
-      firstName: string;
-      lastName: string;
-      phone?: string;
-      birthDate?: string;
-      location?: string;
-      whatsapp?: string;
-      instagram?: string;
-      facebook?: string;
-      linkedin?: string;
-      website?: string;
-      portfolio?: string;
-      cv?: string;
-      picture?: string;
-      bio?: string;
-      experienceYears?: number;
-      professionalGroup?: CategoryGroup;
-      serviceLocations?: string[];
-      hasPhysicalStore?: boolean;
-      physicalStoreAddress?: string;
-      services?: ServiceFormInput[];
-    }
-
+    const payload: RegisterRequestPayload = await request.json();
     const {
       email,
       password,
@@ -65,32 +87,29 @@ export async function POST(request: NextRequest) {
       hasPhysicalStore,
       physicalStoreAddress,
       services,
-    }: RegisterRequestPayload = await request.json();
+    } = payload;
 
-    // Validar datos requeridos
     if (!email || !password || !firstName || !lastName) {
       return NextResponse.json(
-        { error: 'Faltan datos requeridos' },
-        { status: 400 }
+        fail('validation_error', 'Faltan datos requeridos', undefined, metaBase),
+        { status: 400, headers: rateLimitHeaders(rl) }
       );
     }
 
-    // Verificar si el usuario ya existe
     const existingUser = await prisma.user.findUnique({
-      where: { email }
+      where: { email },
+      select: { id: true },
     });
 
     if (existingUser) {
       return NextResponse.json(
-        { error: 'El usuario ya existe' },
-        { status: 400 }
+        fail('conflict', 'El usuario ya existe', undefined, metaBase),
+        { status: 400, headers: rateLimitHeaders(rl) }
       );
     }
 
-    // Hashear la contraseña
     const hashedPassword = await bcrypt.hash(password, 12);
 
-    // Transacción: crear usuario, profesional y servicios
     const result = await prisma.$transaction(async (tx) => {
       const user = await tx.user.create({
         data: {
@@ -101,18 +120,14 @@ export async function POST(request: NextRequest) {
           phone: phone || null,
           birthDate: birthDate ? new Date(birthDate) : null,
           location: location || null,
-          // si picture se usa a futuro, guardar en otro modelo; por ahora ignorado
-        }
+        },
       });
 
       let professional: PrismaProfessional | null = null;
 
-      // Si vienen datos profesionales, crear el perfil
       if (bio || experienceYears || (services && services.length > 0) || professionalGroup) {
-        // Asegurarse de que el grupo de categorías existe
-        // Si no hay professionalGroup, usar 'oficios' por defecto
         const groupToUse = professionalGroup || 'oficios';
-        
+
         const categoryGroupRecord = await tx.categoryGroup.upsert({
           where: { id: groupToUse },
           update: {},
@@ -123,8 +138,10 @@ export async function POST(request: NextRequest) {
           },
         });
 
-        // Mapear category slug -> crear/usar Category y devolver su id
-        let servicesCreateData: Array<{ categoryId: string; title: string; description: string; categoryGroup?: CategoryGroup }> | undefined = undefined;
+        let servicesCreateData:
+          | Array<{ categoryId: string; title: string; description: string; categoryGroup?: CategoryGroup }>
+          | undefined = undefined;
+
         if (services && services.length > 0) {
           servicesCreateData = await Promise.all(
             services.map(async (s: ServiceFormInput) => {
@@ -142,7 +159,7 @@ export async function POST(request: NextRequest) {
                     description: '',
                     slug: s.categoryId,
                     active: true,
-                    groupId: categoryGroupRecord.id, // Usar el ID del grupo que acabamos de crear/obtener
+                    groupId: categoryGroupRecord.id,
                   },
                   select: { id: true },
                 });
@@ -176,23 +193,25 @@ export async function POST(request: NextRequest) {
             serviceLocations: serviceLocations || [],
             hasPhysicalStore: hasPhysicalStore || false,
             physicalStoreAddress: hasPhysicalStore ? physicalStoreAddress : null,
-            services: servicesCreateData && servicesCreateData.length > 0 ? {
-              create: servicesCreateData,
-            } : undefined,
-          }
+            services:
+              servicesCreateData && servicesCreateData.length > 0
+                ? {
+                    create: servicesCreateData,
+                  }
+                : undefined,
+          },
         });
       }
 
-      // Crear token de verificación
-      const token = generateRandomToken(48)
-      const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24) // 24h
+      const token = generateRandomToken(48);
+      const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24); // 24h
       await tx.verificationToken.create({
         data: {
           userId: user.id,
           token,
           expiresAt,
-        }
-      })
+        },
+      });
 
       return { user, professional, token };
     });
@@ -200,7 +219,6 @@ export async function POST(request: NextRequest) {
     const { password: _dbPassword, ...userWithoutPassword } = result.user as PrismaUser;
     void _dbPassword;
 
-    // Envio de correo de verificacion manejado por servicio externo
     try {
       await enqueueEmailVerify({
         userId: userWithoutPassword.id,
@@ -209,46 +227,54 @@ export async function POST(request: NextRequest) {
         firstName: userWithoutPassword.firstName || undefined,
       });
     } catch (e) {
-      console.error('Error encolando correo de verificación:', e);
-      // En desarrollo, imprimir info de debug
+      console.error('Error encolando correo de verificación (v1):', e);
       if (process.env.NODE_ENV !== 'production') {
         const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || process.env.VERCEL_URL || '';
         const origin = baseUrl.startsWith('http') ? baseUrl : `https://${baseUrl}`;
-        const verifyUrl = `${origin}/auth/verify?token=${encodeURIComponent(result.token)}&email=${encodeURIComponent(userWithoutPassword.email)}`;
+        const verifyUrl = `${origin}/auth/verify?token=${encodeURIComponent(result.token)}&email=${encodeURIComponent(
+          userWithoutPassword.email
+        )}`;
         console.log('Verification URL (dev):', verifyUrl);
       }
     }
 
-   
-
-    const devVerifyUrl = process.env.NODE_ENV !== 'production' 
-      ? (() => {
-          const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || process.env.VERCEL_URL || '';
-          const origin = baseUrl.startsWith('http') ? baseUrl : `https://${baseUrl}`;
-          return `${origin}/auth/verify?token=${encodeURIComponent(result.token)}&email=${encodeURIComponent(userWithoutPassword.email)}`;
-        })()
-      : undefined
-
-    return NextResponse.json({
-      message: 'Usuario registrado. Te enviamos un correo para confirmar la cuenta.',
-      user: userWithoutPassword,
-      professional: result.professional,
-      ...(devVerifyUrl ? { devVerifyUrl } : {}),
-    });
-
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Error interno del servidor';
-
-    // Log detallado
-    console.error('Error al registrar usuario:', error);
-    if (error instanceof Error && error.stack) {
-      console.error('Stack de registro:', error.stack);
+    if (result.professional) {
+      enqueueSlackAlert(
+        `prof:new:${result.professional.id}`,
+        `🔔 Nuevo profesional registrado (pendiente):\n*${userWithoutPassword.firstName} ${userWithoutPassword.lastName}*\nEmail: ${userWithoutPassword.email}\nGrupo: ${result.professional.professionalGroup || 'N/A'}\nServicios: ${payload.services?.length || 0}`
+      ).catch((slackError) => console.error('Error enviando alerta a Slack:', slackError));
     }
 
-    const isValidation = message.toLowerCase().includes('categoría no encontrada') || message.toLowerCase().includes('faltan datos');
+    const devVerifyUrl =
+      process.env.NODE_ENV !== 'production'
+        ? (() => {
+            const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || process.env.VERCEL_URL || '';
+            const origin = baseUrl.startsWith('http') ? baseUrl : `https://${baseUrl}`;
+            return `${origin}/auth/verify?token=${encodeURIComponent(result.token)}&email=${encodeURIComponent(
+              userWithoutPassword.email
+            )}`;
+          })()
+        : undefined;
+
     return NextResponse.json(
-      { error: message },
-      { status: isValidation ? 400 : 500 }
+      ok(
+        {
+          message: 'Usuario registrado. Te enviamos un correo para confirmar la cuenta.',
+          user: userWithoutPassword,
+          professional: result.professional,
+          ...(devVerifyUrl ? { devVerifyUrl } : {}),
+        },
+        metaBase
+      ),
+      { status: 201, headers: rateLimitHeaders(rl) }
     );
-  } 
+  } catch (error) {
+    console.error('Error al registrar usuario (v1):', error);
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    const isValidation = message.toLowerCase().includes('categoría no encontrada') || message.toLowerCase().includes('faltan datos');
+    return NextResponse.json(fail(isValidation ? 'validation_error' : 'server_error', message, undefined, metaBase), {
+      status: isValidation ? 400 : 500,
+      headers: rateLimitHeaders(rl),
+    });
+  }
 }

--- a/src/app/api/v1/auth/verify/route.ts
+++ b/src/app/api/v1/auth/verify/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { ok, fail, requestMeta } from '@/lib/api-response';
+import { rateLimit, rateLimitHeaders } from '@/lib/rate-limit-memory';
+
+const LIMIT = 30;
+const WINDOW_MS = 10 * 60 * 1000; // 10 min
+
+function clientIp(req: NextRequest) {
+  return (
+    req.headers.get('x-real-ip') ||
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const meta = requestMeta(request);
+  const rl = rateLimit(`auth-verify:${clientIp(request)}`, LIMIT, WINDOW_MS);
+
+  if (!rl.allowed) {
+    return NextResponse.json(
+      fail('rate_limited', 'Demasiadas solicitudes. Intenta más tarde.', undefined, meta),
+      { status: 429, headers: rateLimitHeaders(rl) }
+    );
+  }
+
+  try {
+    const { token, email } = await request.json();
+    if (!token || !email) {
+      return NextResponse.json(
+        fail('validation_error', 'Datos incompletos', undefined, meta),
+        { status: 400, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      return NextResponse.json(
+        fail('not_found', 'Usuario no encontrado', undefined, meta),
+        { status: 404, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    const record = await prisma.verificationToken.findFirst({
+      where: { userId: user.id, token },
+    });
+
+    if (!record) {
+      return NextResponse.json(
+        fail('invalid_token', 'Token inválido', undefined, meta),
+        { status: 400, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    if (record.expiresAt < new Date()) {
+      await prisma.verificationToken.delete({ where: { id: record.id } });
+      return NextResponse.json(
+        fail('expired_token', 'Token expirado', undefined, meta),
+        { status: 400, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    await prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: user.id },
+        data: { verified: true, emailVerifiedAt: new Date() },
+      });
+      await tx.verificationToken.delete({ where: { id: record.id } });
+    });
+
+    return NextResponse.json(ok({ message: 'Cuenta verificada' }, meta), {
+      headers: rateLimitHeaders(rl),
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Error interno del servidor';
+    return NextResponse.json(fail('server_error', message, undefined, meta), {
+      status: 500,
+      headers: rateLimitHeaders(rl),
+    });
+  }
+}

--- a/src/app/api/v1/bug-reports/route.ts
+++ b/src/app/api/v1/bug-reports/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { enqueueSlackAlert } from '@/jobs/slack.producer';
+import { fail, ok, requestMeta } from '@/lib/api-response';
+import { rateLimit, rateLimitHeaders } from '@/lib/rate-limit-memory';
+
+const LIMIT = 20; // requests
+const WINDOW_MS = 10 * 60 * 1000; // 10 minutes
+
+function clientIp(req: NextRequest) {
+  return (
+    req.headers.get('x-real-ip') ||
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const meta = requestMeta(request);
+  const ip = clientIp(request);
+  const rl = rateLimit(`bug:${ip}`, LIMIT, WINDOW_MS);
+
+  if (!rl.allowed) {
+    return NextResponse.json(
+      fail('rate_limited', 'Demasiadas solicitudes. Intenta más tarde.', undefined, meta),
+      { status: 429, headers: rateLimitHeaders(rl) }
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const { title, description, severity = 'medium', userEmail, context } = body ?? {};
+
+    if (!title || !description) {
+      return NextResponse.json(
+        fail('validation_error', 'Título y descripción son requeridos', undefined, meta),
+        { status: 400, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    if (!['low', 'medium', 'high', 'critical'].includes(severity)) {
+      return NextResponse.json(
+        fail('validation_error', 'Severidad inválida', { allowed: ['low', 'medium', 'high', 'critical'] }, meta),
+        { status: 400, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    let userId: string | null = null;
+    if (userEmail) {
+      const user = await prisma.user.findUnique({
+        where: { email: userEmail },
+        select: { id: true },
+      });
+      userId = user?.id || null;
+    }
+
+    const bugReport = await prisma.bugReport.create({
+      data: {
+        title,
+        description,
+        severity,
+        userEmail: userEmail || null,
+        userId,
+        context: context || null,
+        status: 'open',
+      },
+    });
+
+    // Best-effort notification
+    enqueueSlackAlert(
+      `bug:${bugReport.id}`,
+      `🐛 Nuevo bug reportado:\n*${title}*\nSeveridad: ${severity}\n${userEmail ? `Reportado por: ${userEmail}` : 'Reporte anónimo'}`
+    ).catch((slackError) => {
+      console.error('Error enviando alerta a Slack:', slackError);
+    });
+
+    return NextResponse.json(
+      ok(
+        bugReport,
+        {
+          ...meta,
+          pagination: undefined,
+        }
+      ),
+      { status: 201, headers: rateLimitHeaders(rl) }
+    );
+  } catch (error) {
+    console.error('Error creando bug report (v1):', error);
+    return NextResponse.json(
+      fail('server_error', 'Error al reportar bug', undefined, meta),
+      { status: 500, headers: rateLimitHeaders(rl) }
+    );
+  }
+}

--- a/src/app/api/v1/categories/route.ts
+++ b/src/app/api/v1/categories/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { ok, fail, requestMeta } from '@/lib/api-response';
+import { rateLimit, rateLimitHeaders } from '@/lib/rate-limit-memory';
+
+const LIMIT = 60;
+const WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+function clientIp(req: Request) {
+  return (
+    req.headers.get('x-real-ip') ||
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  );
+}
+
+export async function GET(request: Request) {
+  const meta = requestMeta(request);
+  const rl = rateLimit(`categories:${clientIp(request)}`, LIMIT, WINDOW_MS);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      fail('rate_limited', 'Demasiadas solicitudes. Intenta más tarde.', undefined, meta),
+      { status: 429, headers: rateLimitHeaders(rl) }
+    );
+  }
+
+  try {
+    const [areas, subcatOficios, subcatProfesiones, counts] = await Promise.all([
+      prisma.category.findMany({
+        where: { groupId: 'oficios', parentCategoryId: null, active: true },
+        select: { id: true, name: true, slug: true, groupId: true, backgroundUrl: true, description: true, active: true },
+        orderBy: { name: 'asc' },
+      }),
+      prisma.category.findMany({
+        where: { groupId: 'oficios', parentCategoryId: { not: null }, active: true },
+        include: { parent: { select: { id: true, name: true, slug: true } } },
+        orderBy: { name: 'asc' },
+      }),
+      prisma.category.findMany({
+        where: { groupId: 'profesiones', active: true },
+        orderBy: { name: 'asc' },
+      }),
+      prisma.service.groupBy({
+        by: ['categoryId'],
+        _count: { categoryId: true },
+        where: { professional: { status: 'active' } },
+      }),
+    ]);
+
+    const countMap = new Map<string, number>();
+    counts.forEach((c) => countMap.set(c.categoryId, c._count.categoryId));
+
+    const subcategoriesOficios = subcatOficios.map((sub) => ({
+      id: sub.id,
+      name: sub.name,
+      slug: sub.slug,
+      group: sub.groupId,
+      areaId: sub.parentCategoryId,
+      areaSlug: sub.parent?.slug ?? null,
+      image: sub.backgroundUrl,
+      description: sub.description,
+      active: sub.active,
+      professionalCount: countMap.get(sub.id) || 0,
+    }));
+
+    const subcategoriesProfesiones = subcatProfesiones.map((sub) => ({
+      id: sub.id,
+      name: sub.name,
+      slug: sub.slug,
+      group: sub.groupId,
+      areaId: null,
+      areaSlug: null,
+      image: sub.backgroundUrl,
+      description: sub.description,
+      active: sub.active,
+      professionalCount: countMap.get(sub.id) || 0,
+    }));
+
+    const areasWithCounts = areas.map((area) => {
+      const subs = subcategoriesOficios.filter((s) => s.areaSlug === area.slug);
+      const professionalCount = subs.reduce((sum, s) => sum + s.professionalCount, 0);
+      const subcategoryCount = subs.length;
+      return {
+        id: area.id,
+        name: area.name,
+        slug: area.slug,
+        group: area.groupId,
+        image: area.backgroundUrl,
+        description: area.description,
+        active: area.active,
+        subcategoryCount,
+        professionalCount,
+      };
+    });
+
+    return NextResponse.json(
+      ok(
+        {
+          areas: areasWithCounts,
+          subcategoriesOficios,
+          subcategoriesProfesiones,
+        },
+        meta
+      ),
+      { headers: rateLimitHeaders(rl) }
+    );
+  } catch (error) {
+    console.error('Error obteniendo categorías (v1):', error);
+    return NextResponse.json(
+      fail('server_error', 'Error al obtener categorías', undefined, meta),
+      { status: 500, headers: rateLimitHeaders(rl) }
+    );
+  }
+}

--- a/src/app/api/v1/professionals/route.ts
+++ b/src/app/api/v1/professionals/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { ok, fail, requestMeta } from '@/lib/api-response';
+import { rateLimit, rateLimitHeaders } from '@/lib/rate-limit-memory';
+
+const LIMIT = 120;
+const WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+function clientIp(req: NextRequest) {
+  return (
+    req.headers.get('x-real-ip') ||
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const metaBase = requestMeta(request);
+  const { searchParams } = new URL(request.url);
+
+  const rl = rateLimit(`professionals:${clientIp(request)}`, LIMIT, WINDOW_MS);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      fail('rate_limited', 'Demasiadas solicitudes. Intenta más tarde.', undefined, metaBase),
+      { status: 429, headers: rateLimitHeaders(rl) }
+    );
+  }
+
+  try {
+    const q = searchParams.get('q') || undefined;
+    const categoria = searchParams.get('categoria') || undefined; // slug de subcategoría
+    const grupo = searchParams.get('grupo') as 'oficios' | 'profesiones' | null;
+    const location = searchParams.get('location') || undefined;
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
+    const pageSize = Math.min(50, Math.max(1, parseInt(searchParams.get('limit') || '12', 10)));
+    const sortBy = (searchParams.get('sortBy') || 'recent') as 'name' | 'rating' | 'recent';
+
+    const where: Prisma.ProfessionalWhereInput = {
+      status: 'active',
+    };
+
+    if (grupo) {
+      where.professionalGroup = grupo;
+    }
+
+    if (categoria) {
+      where.services = {
+        some: {
+          category: { slug: categoria },
+        },
+      };
+    }
+
+    if (location && location !== 'all') {
+      const locationFilter: Prisma.ProfessionalWhereInput = {
+        OR: [
+          { serviceLocations: { has: location } },
+          { serviceLocations: { has: 'all-region' } },
+          { location: location },
+        ],
+      };
+
+      where.AND = Array.isArray(where.AND) ? [...where.AND, locationFilter] : [locationFilter];
+    }
+
+    if (q) {
+      const searchFilter: Prisma.ProfessionalWhereInput = {
+        OR: [
+          { bio: { contains: q, mode: Prisma.QueryMode.insensitive } },
+          { user: { firstName: { contains: q, mode: Prisma.QueryMode.insensitive } } },
+          { user: { lastName: { contains: q, mode: Prisma.QueryMode.insensitive } } },
+          { services: { some: { title: { contains: q, mode: Prisma.QueryMode.insensitive } } } },
+          { services: { some: { description: { contains: q, mode: Prisma.QueryMode.insensitive } } } },
+          { services: { some: { category: { name: { contains: q, mode: Prisma.QueryMode.insensitive } } } } },
+        ],
+      };
+
+      where.AND = Array.isArray(where.AND) ? [...where.AND, searchFilter] : [searchFilter];
+    }
+
+    let orderBy: Prisma.ProfessionalOrderByWithRelationInput = { createdAt: 'desc' };
+    if (sortBy === 'name') {
+      orderBy = { user: { firstName: 'asc' } };
+    } else if (sortBy === 'rating') {
+      orderBy = { rating: 'desc' };
+    }
+
+    const [total, rows] = await Promise.all([
+      prisma.professional.count({ where }),
+      prisma.professional.findMany({
+        where,
+        orderBy,
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+        select: {
+          id: true,
+          bio: true,
+          verified: true,
+          rating: true,
+          reviewCount: true,
+          location: true,
+          ProfilePicture: true,
+          whatsapp: true,
+          serviceLocations: true,
+          user: {
+            select: {
+              firstName: true,
+              lastName: true,
+              verified: true,
+              image: true,
+              location: true,
+              phone: true,
+            },
+          },
+          services: {
+            take: 1,
+            orderBy: { createdAt: 'asc' },
+            include: { category: { select: { name: true } } },
+          },
+        },
+      }),
+    ]);
+
+    const data = rows.map((p) => ({
+      id: p.id,
+      user: { name: `${p.user.firstName} ${p.user.lastName}`.trim() },
+      bio: p.bio,
+      verified: p.verified || p.user.verified,
+      primaryCategory: { name: p.services[0]?.category?.name ?? undefined },
+      location: p.location ?? p.user.location ?? undefined,
+      rating: p.rating ?? 0,
+      reviewCount: p.reviewCount ?? 0,
+      ProfilePicture: p.ProfilePicture || p.user.image || undefined,
+      whatsapp: p.whatsapp || undefined,
+      phone: p.user.phone || undefined,
+      serviceLocations: p.serviceLocations ?? [],
+    }));
+
+    const meta = {
+      ...metaBase,
+      pagination: {
+        page,
+        pageSize,
+        total,
+      },
+    };
+
+    return NextResponse.json(ok(data, meta), {
+      headers: rateLimitHeaders(rl),
+    });
+  } catch (error) {
+    console.error('Get professionals v1 error:', error);
+    return NextResponse.json(
+      fail('server_error', 'Error al obtener profesionales', undefined, metaBase),
+      { status: 500, headers: rateLimitHeaders(rl) }
+    );
+  }
+}

--- a/src/app/api/v1/services/route.ts
+++ b/src/app/api/v1/services/route.ts
@@ -1,0 +1,282 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma, CategoryGroupId } from '@prisma/client';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/options';
+import { AREAS_OFICIOS, SUBCATEGORIES_OFICIOS, SUBCATEGORIES_PROFESIONES } from '@/lib/taxonomy';
+import { prisma } from '@/lib/prisma';
+import { ok, fail, requestMeta } from '@/lib/api-response';
+import { rateLimit, rateLimitHeaders } from '@/lib/rate-limit-memory';
+
+const RL_LIST = { limit: 200, windowMs: 5 * 60 * 1000 }; // 200 req / 5 min por IP
+const RL_POST = { limit: 40, windowMs: 10 * 60 * 1000 }; // 40 req / 10 min por IP
+
+function clientIp(req: NextRequest) {
+  return (
+    req.headers.get('x-real-ip') ||
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown'
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const metaBase = requestMeta(request);
+  const rl = rateLimit(`services:list:${clientIp(request)}`, RL_LIST.limit, RL_LIST.windowMs);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      fail('rate_limited', 'Demasiadas solicitudes. Intenta más tarde.', undefined, metaBase),
+      { status: 429, headers: rateLimitHeaders(rl) }
+    );
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+
+    const limit = Math.min(Number(searchParams.get('limit')) || 20, 50);
+    const page = Math.max(Number(searchParams.get('page')) || 1, 1);
+    const q = (searchParams.get('q') || '').trim();
+
+    let grupo = searchParams.get('grupo') as 'oficios' | 'profesiones' | null;
+    const subcategoriaSlug = searchParams.get('subcategoria');
+    let categoriaSlug = searchParams.get('categoria') || null;
+    const location = searchParams.get('location') || null;
+
+    const where: Prisma.ServiceWhereInput = {
+      available: true,
+      professional: {
+        status: 'active',
+        user: { verified: true },
+      },
+    };
+
+    if (subcategoriaSlug) {
+      categoriaSlug = subcategoriaSlug;
+    }
+
+    if (q && !categoriaSlug) {
+      const normalized = q.toLowerCase();
+      const allTaxonomy = [...SUBCATEGORIES_OFICIOS, ...SUBCATEGORIES_PROFESIONES];
+      const matched = allTaxonomy.find(
+        (subcat) =>
+          subcat.name.toLowerCase().includes(normalized) ||
+          subcat.slug.toLowerCase().includes(normalized)
+      );
+
+      if (matched) {
+        categoriaSlug = matched.slug;
+        if (!grupo) {
+          grupo = matched.group as 'oficios' | 'profesiones';
+        }
+      }
+    }
+
+    if (grupo) {
+      const groupEnum = grupo === 'oficios' ? CategoryGroupId.oficios : CategoryGroupId.profesiones;
+      const baseProfessional = (where.professional as Prisma.ProfessionalWhereInput) || {};
+      where.professional = {
+        ...baseProfessional,
+        professionalGroup: groupEnum,
+      };
+    }
+
+    if (categoriaSlug) {
+      const areaMatch = AREAS_OFICIOS.find((area) => area.slug === categoriaSlug);
+
+      if (areaMatch) {
+        const subSlugs = SUBCATEGORIES_OFICIOS.filter((sub) => sub.areaSlug === areaMatch.slug).map(
+          (sub) => sub.slug
+        );
+
+        where.category = subSlugs.length > 0 ? { slug: { in: subSlugs } } : { slug: categoriaSlug };
+      } else {
+        where.category = { slug: categoriaSlug };
+      }
+    }
+
+    if (location && location !== 'all') {
+      const baseProfessional = (where.professional as Prisma.ProfessionalWhereInput) || {};
+      where.professional = {
+        ...baseProfessional,
+        OR: [
+          { serviceLocations: { has: location } },
+          { serviceLocations: { has: 'all-region' } },
+          { location: location },
+        ],
+      };
+    }
+
+    if (q) {
+      where.OR = [
+        { title: { contains: q, mode: 'insensitive' } },
+        { description: { contains: q, mode: 'insensitive' } },
+        { category: { name: { contains: q, mode: 'insensitive' } } },
+        {
+          professional: {
+            user: {
+              OR: [
+                { firstName: { contains: q, mode: 'insensitive' } },
+                { lastName: { contains: q, mode: 'insensitive' } },
+              ],
+            },
+          },
+        },
+      ];
+    }
+
+    const [total, services] = await Promise.all([
+      prisma.service.count({ where }),
+      prisma.service.findMany({
+        where,
+        include: {
+          category: { select: { name: true } },
+          professional: {
+            select: {
+              id: true,
+              location: true,
+              verified: true,
+              rating: true,
+              reviewCount: true,
+              ProfilePicture: true,
+              whatsapp: true,
+              user: { select: { firstName: true, lastName: true, verified: true, location: true, phone: true } },
+            },
+          },
+        },
+        orderBy: [{ createdAt: 'desc' }],
+        take: limit,
+        skip: (page - 1) * limit,
+      }),
+    ]);
+
+    const data = services.map((s) => ({
+      id: s.id,
+      title: s.title,
+      description: s.description,
+      priceRange: s.priceRange,
+      professional: {
+        id: s.professional.id,
+        location: s.professional.location ?? s.professional.user.location ?? null,
+        whatsapp: s.professional.whatsapp ?? null,
+        phone: s.professional.user.phone ?? null,
+        user: {
+          name: `${s.professional.user.firstName} ${s.professional.user.lastName}`.trim(),
+          location: s.professional.user.location ?? null,
+        },
+        rating: s.professional.rating ?? 0,
+        reviewCount: s.professional.reviewCount ?? 0,
+        verified: s.professional.verified,
+        ProfilePicture: s.professional.ProfilePicture ?? null,
+      },
+      category: { name: s.category.name },
+    }));
+
+    const meta = {
+      ...metaBase,
+      pagination: { page, pageSize: limit, total },
+    };
+
+    return NextResponse.json(ok(data, meta), { headers: rateLimitHeaders(rl) });
+  } catch (error) {
+    console.error('List services v1 error:', error);
+
+    const message =
+      error instanceof Error && error.message
+        ? `Error al obtener servicios. Detalle: ${error.message}`
+        : 'Error al obtener servicios';
+
+    return NextResponse.json(fail('fetch_failed', message, undefined, metaBase), {
+      status: 500,
+      headers: rateLimitHeaders(rl),
+    });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const metaBase = requestMeta(request);
+  const rl = rateLimit(`services:create:${clientIp(request)}`, RL_POST.limit, RL_POST.windowMs);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      fail('rate_limited', 'Demasiadas solicitudes. Intenta más tarde.', undefined, metaBase),
+      { status: 429, headers: rateLimitHeaders(rl) }
+    );
+  }
+
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        fail('unauthorized', 'No autorizado', undefined, metaBase),
+        { status: 401, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    const body = await request.json();
+    const { title, description, categorySlug, priceRange } = body as {
+      title: string;
+      description: string;
+      categorySlug: string;
+      priceRange?: string;
+    };
+
+    if (!title || !description || !categorySlug) {
+      return NextResponse.json(
+        fail('invalid_body', 'Faltan campos requeridos', undefined, metaBase),
+        { status: 400, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    const professional = await prisma.professional.findUnique({
+      where: { userId: session.user.id },
+    });
+    if (!professional) {
+      return NextResponse.json(
+        fail('no_professional', 'Perfil profesional no encontrado', undefined, metaBase),
+        { status: 404, headers: rateLimitHeaders(rl) }
+      );
+    }
+
+    let category = await prisma.category.findUnique({ where: { slug: categorySlug } });
+    if (!category) {
+      const allTaxonomy = [...SUBCATEGORIES_OFICIOS, ...SUBCATEGORIES_PROFESIONES];
+      const match = allTaxonomy.find((c) => c.slug === categorySlug);
+      if (match) {
+        category = await prisma.category.create({
+          data: {
+            name: match.name,
+            description: match.name,
+            slug: match.slug,
+            active: true,
+            group: { connect: { id: match.group } },
+          },
+        });
+      } else {
+        return NextResponse.json(
+          fail('category_not_found', 'Categoría no encontrada', undefined, metaBase),
+          { status: 404, headers: rateLimitHeaders(rl) }
+        );
+      }
+    }
+
+    const created = await prisma.service.create({
+      data: {
+        professionalId: professional.id,
+        categoryId: category.id,
+        categoryGroup: professional.professionalGroup ?? null,
+        title,
+        description,
+        priceRange: priceRange || '',
+        available: true,
+      },
+      include: {
+        category: { select: { name: true } },
+      },
+    });
+
+    return NextResponse.json(ok(created, metaBase), { status: 201, headers: rateLimitHeaders(rl) });
+  } catch (error) {
+    console.error('POST /api/v1/services error:', error);
+    return NextResponse.json(
+      fail('server_error', 'Error al crear servicio', undefined, metaBase),
+      { status: 500, headers: rateLimitHeaders(rl) }
+    );
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -330,7 +330,6 @@ export default function DashboardPage() {
       try {
         const response = await fetch('/api/professional/stats');
         const result = await response.json();
-        console.log('Stats response:', result);
 
         // Si no está autorizado, no mostramos toast ni marcamos error visual
         if (response.status === 401 || result.error === 'unauthorized') {

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -1,0 +1,44 @@
+export type ApiError = {
+  code: string;
+  message: string;
+  details?: unknown;
+};
+
+export type ApiMeta = {
+  requestId: string;
+  pagination?: {
+    page?: number;
+    pageSize?: number;
+    total?: number;
+  };
+};
+
+export type ApiSuccess<T> = {
+  success: true;
+  data: T;
+  meta?: ApiMeta;
+};
+
+export type ApiFailure = {
+  success: false;
+  error: ApiError;
+  meta?: ApiMeta;
+};
+
+export function ok<T>(data: T, meta?: ApiMeta): ApiSuccess<T> {
+  return { success: true, data, ...(meta ? { meta } : {}) };
+}
+
+export function fail(code: string, message: string, details?: unknown, meta?: ApiMeta): ApiFailure {
+  return { success: false, error: { code, message, ...(details ? { details } : {}) }, ...(meta ? { meta } : {}) };
+}
+
+export function requestMeta(req: Request, extras?: Partial<ApiMeta>): ApiMeta {
+  const requestId =
+    req.headers.get('x-request-id') ||
+    req.headers.get('x-cf-ray') ||
+    req.headers.get('x-vercel-id') ||
+    crypto.randomUUID();
+
+  return { requestId, ...(extras ?? {}) };
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,13 +1,22 @@
 import { PrismaClient } from '@prisma/client';
 
+const isProd = process.env.NODE_ENV === 'production';
+
 declare global {
   var prismaGlobal: PrismaClient | undefined;
 }
 
-export const prisma: PrismaClient = global.prismaGlobal || new PrismaClient();
+/**
+ * Singleton de Prisma con logging controlado para evitar
+ * pools excesivos y facilitar debugging en dev.
+ */
+export const prisma: PrismaClient =
+  global.prismaGlobal ||
+  new PrismaClient({
+    log: isProd ? ['warn', 'error'] : ['query', 'warn', 'error'],
+    errorFormat: isProd ? 'minimal' : 'pretty',
+  });
 
-if (process.env.NODE_ENV !== 'production') {
+if (!isProd) {
   global.prismaGlobal = prisma;
 }
-
-

--- a/src/lib/rate-limit-memory.ts
+++ b/src/lib/rate-limit-memory.ts
@@ -1,0 +1,38 @@
+// In-memory rate limiter (fixed window) for app router handlers.
+// Note: In serverless this is best-effort (per-instance); still useful to throttle abuse.
+
+type Bucket = { count: number; resetAt: number };
+
+const buckets = new Map<string, Bucket>();
+
+export type RateLimitResult = {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+};
+
+export function rateLimit(key: string, limit: number, windowMs: number): RateLimitResult {
+  const now = Date.now();
+  const bucket = buckets.get(key);
+
+  if (!bucket || bucket.resetAt <= now) {
+    const resetAt = now + windowMs;
+    buckets.set(key, { count: 1, resetAt });
+    return { allowed: true, remaining: limit - 1, resetAt };
+  }
+
+  if (bucket.count >= limit) {
+    return { allowed: false, remaining: 0, resetAt: bucket.resetAt };
+  }
+
+  bucket.count += 1;
+  return { allowed: true, remaining: limit - bucket.count, resetAt: bucket.resetAt };
+}
+
+export function rateLimitHeaders(result: RateLimitResult) {
+  return {
+    'X-RateLimit-Limit': String(result.remaining + 1),
+    'X-RateLimit-Remaining': String(result.remaining),
+    'X-RateLimit-Reset': String(Math.ceil(result.resetAt / 1000)),
+  };
+}


### PR DESCRIPTION
## Qué cambia
 - API v1 añadida (compat sin romper legacy): bug-reports, categories, services (GET/POST), professionals (GET), auth/register, auth/complete-profile, auth/password/reset, auth/verify con envelope consistente y rate limits por IP.
 - Trazabilidad y límites: middleware x-request-id en /api/*; helper de rate limit in-memory reutilizable.
 - Docs: OpenAPI v1 (openapi-v1.yaml); endpoints /api/docs (YAML) y /api/docs/ui (Swagger UI) deshabilitables en prod con ALLOW_API_DOCS=false.
 - Optimización: GET /api/categories sin N+1 (usa groupBy), Prisma client con logging por entorno y singleton.
 - Infra/env: hint de connection_limit/pool_timeout en .envexample.
 - Build & tests: npm run build pasa (solo warnings legacy de ESLint); npm test pasa (90/92 tests, 2 skipped UI).

## Cómo se probó
- [x] Unit
- [x] Integration
- [x] E2E
Comandos: `npm run test`, `npm run test:e2e`

## Checklist
- [x] Typecheck / Lint ok
- [ ] Estados vacíos/errores cubiertos
- [ ] Mensajes accesibles (roles/labels)
- [ ] Issue linkeado: #123