### PR TITLE
fix: clean .next before build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,9 @@ jobs:
             echo "🗄️ Generando Prisma Client..."
             npx prisma generate
             
+            echo "🧹 Limpiando build anterior (evita EACCES por permisos de root)..."
+            sudo rm -rf .next
+            
             echo "🔨 Construyendo aplicación (Next.js)..."
             npm run build
             


### PR DESCRIPTION

**Causa raíz:** PM2 corre con `sudo` (como root), creando la carpeta `.next/` con permisos de root. Cuando el siguiente deploy ejecuta `npm run build` como el usuario SSH (no root), no puede escribir en `.next/trace`.

## Solución

Agregar `sudo rm -rf .next` antes del `npm run build` en el script de deploy. Esto:
- Elimina el build anterior con permisos de root
- Garantiza un build limpio en cada deploy
- Evita conflictos de permisos entre el usuario SSH y root (PM2)

## Impacto

Solo afecta el pipeline de deploy. No toca código de la aplicación.