### PR TITLE
feat: ajustes auth/register y validaciones sin cambios UI

### DIFF
--- a/src/app/api/v1/auth/register/route.ts
+++ b/src/app/api/v1/auth/register/route.ts
@@ -6,7 +6,7 @@ import { prisma } from '@/lib/prisma';
 import { generateRandomToken } from '@/lib/utils';
 import { enqueueEmailVerify } from '@/jobs/email.producer';
 import { enqueueSlackAlert } from '@/jobs/slack.producer';
-import { normalizeWhatsAppNumber } from '@/lib/whatsapp-normalize';
+import { normalizeWhatsAppNumber, validateWhatsAppNumber } from '@/lib/whatsapp-normalize';
 import { ok, fail, requestMeta } from '@/lib/api-response';
 import { rateLimit, rateLimitHeaders } from '@/lib/rate-limit-memory';
 import { buildChanges, observedJson, safeRecordAuditEvent } from '@/lib/observability/audit';
@@ -41,6 +41,7 @@ interface RegisterRequestPayload {
   password: string;
   firstName: string;
   lastName: string;
+  gender?: string;
   dni?: string;
   phone?: string;
   birthDate?: string;
@@ -54,7 +55,7 @@ interface RegisterRequestPayload {
   cv?: string;
   picture?: string;
   bio?: string;
-  experienceYears?: number;
+  experienceYears?: number | string | null;
   professionalGroup?: CategoryGroup;
   serviceLocations?: string[];
   hasPhysicalStore?: boolean;
@@ -63,11 +64,131 @@ interface RegisterRequestPayload {
   services?: ServiceFormInput[];
 }
 
+function isValidProfessionalGroup(value: unknown): value is CategoryGroup {
+  return value === 'oficios' || value === 'profesiones';
+}
+
+function calculateAge(birthDate: Date, today = new Date()) {
+  const age = today.getFullYear() - birthDate.getFullYear();
+  const monthDiff = today.getMonth() - birthDate.getMonth();
+
+  return monthDiff < 0 || (monthDiff === 0 && today.getDate() < birthDate.getDate())
+    ? age - 1
+    : age;
+}
+
+function normalizeExperienceYears(value: RegisterRequestPayload['experienceYears']) {
+  if (value === undefined || value === null || value === '') {
+    return 0;
+  }
+
+  const years = Number(value);
+  if (!Number.isFinite(years) || years < 0) {
+    return null;
+  }
+
+  return years;
+}
+
+function validateRegistrationPayload(payload: RegisterRequestPayload) {
+  const {
+    email,
+    password,
+    firstName,
+    lastName,
+    dni,
+    birthDate,
+    location,
+    whatsapp,
+    bio,
+    professionalGroup,
+    serviceLocations,
+    services,
+    experienceYears,
+  } = payload;
+
+  if (!email || !password || !firstName || !lastName || !dni) {
+    return 'Faltan datos requeridos (email, contrasena, nombre, apellido y DNI son obligatorios)';
+  }
+
+  if (!/^\S+@\S+\.\S+$/.test(email.trim())) {
+    return 'Ingresa un email valido';
+  }
+
+  if (password.length < 6) {
+    return 'La contrasena debe tener al menos 6 caracteres';
+  }
+
+  if (!/^\d{7,8}$/.test(dni.trim())) {
+    return 'El DNI debe tener entre 7 y 8 digitos';
+  }
+
+  if (!birthDate) {
+    return 'La fecha de nacimiento es requerida';
+  }
+
+  const parsedBirthDate = new Date(birthDate);
+  if (Number.isNaN(parsedBirthDate.getTime())) {
+    return 'La fecha de nacimiento es invalida';
+  }
+
+  if (calculateAge(parsedBirthDate) < 18) {
+    return 'Debes ser mayor de 18 anos para registrarte';
+  }
+
+  if (!location?.trim()) {
+    return 'La localidad es requerida';
+  }
+
+  if (!bio?.trim()) {
+    return 'La descripcion profesional es requerida';
+  }
+
+  const normalizedExperienceYears = normalizeExperienceYears(experienceYears);
+  if (normalizedExperienceYears === null) {
+    return 'Los anos de experiencia deben ser un numero mayor o igual a 0';
+  }
+
+  if (!isValidProfessionalGroup(professionalGroup)) {
+    return 'Debes elegir un grupo profesional valido';
+  }
+
+  if (!serviceLocations || serviceLocations.length === 0) {
+    return 'Debes agregar al menos una localidad donde ofreces tus servicios';
+  }
+
+  if (!whatsapp?.trim()) {
+    return 'El WhatsApp es requerido';
+  }
+
+  const whatsappError = validateWhatsAppNumber(whatsapp);
+  if (whatsappError) {
+    return `WhatsApp invalido: ${whatsappError}`;
+  }
+
+  if (!services || services.length === 0) {
+    return 'Debes agregar al menos un servicio';
+  }
+
+  for (const [index, service] of services.entries()) {
+    if (!service.categoryId?.trim()) {
+      return `La categoria del servicio ${index + 1} es requerida`;
+    }
+
+    if (!service.description?.trim()) {
+      return `La descripcion del servicio ${index + 1} es requerida`;
+    }
+  }
+
+  return null;
+}
+
 function registrationAuditSnapshot(input: {
   user: Omit<PrismaUser, 'password'>;
   professional: PrismaProfessional | null;
   servicesCount: number;
   skipEmailVerification: boolean;
+  emailVerificationQueued: boolean;
 }) {
   return {
     userId: input.user.id,
@@ -75,12 +196,14 @@ function registrationAuditSnapshot(input: {
     firstName: input.user.firstName,
     lastName: input.user.lastName,
     dni: input.user.dni,
+    gender: input.user.gender,
     verified: input.user.verified,
     professionalId: input.professional?.id ?? null,
     professionalStatus: input.professional?.status ?? null,
     professionalGroup: input.professional?.professionalGroup ?? null,
     servicesCount: input.servicesCount,
     skipEmailVerification: input.skipEmailVerification,
+    emailVerificationQueued: input.emailVerificationQueued,
   };
 }
 
@@ -107,6 +230,7 @@ export async function POST(request: NextRequest) {
       password,
       firstName,
       lastName,
+      gender,
       dni,
       phone,
       birthDate,
@@ -135,14 +259,15 @@ export async function POST(request: NextRequest) {
     });
 
     const documentationInput = normalizeProfessionalDocumentationInput(documentation);
+    const validationError = validateRegistrationPayload(payload);
 
-    if (!email || !password || !firstName || !lastName || !dni) {
+    if (validationError) {
       await safeRecordAuditEvent({
         kind: 'audit',
         domain: 'auth',
         eventName: 'auth.register',
         status: 'warning',
-        summary: 'Intento de registro con datos incompletos',
+        summary: 'Intento de registro con datos invalidos',
         actor: context.actor,
         requestId: context.requestId,
         route: context.route,
@@ -157,23 +282,16 @@ export async function POST(request: NextRequest) {
 
       return observedJson(
         context,
-        fail(
-          'validation_error',
-          'Faltan datos requeridos (email, contrasena, nombre, apellido y DNI son obligatorios)',
-          undefined,
-          metaBase,
-        ),
+        fail('validation_error', validationError, undefined, metaBase),
         { status: 400, headers: rateLimitHeaders(rl) },
       );
     }
 
-    if (!/^\d{7,8}$/.test(dni.trim())) {
-      return observedJson(
-        context,
-        fail('validation_error', 'El DNI debe tener entre 7 y 8 digitos', undefined, metaBase),
-        { status: 400, headers: rateLimitHeaders(rl) },
-      );
-    }
+    const normalizedExperienceYears = normalizeExperienceYears(experienceYears) ?? 0;
+    const normalizedDni = dni?.trim() ?? '';
+    const categorySlugs = Array.from(
+      new Set((services ?? []).map((service) => service.categoryId.trim()).filter(Boolean)),
+    );
 
     const existingUser = await prisma.user.findUnique({
       where: { email },
@@ -202,16 +320,41 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const categories = await prisma.category.findMany({
+      where: {
+        slug: { in: categorySlugs },
+        active: true,
+      },
+      select: { id: true, slug: true },
+    });
+    const categoryBySlug = new Map(categories.map((category) => [category.slug, category]));
+    const missingCategory = categorySlugs.find((slug) => !categoryBySlug.has(slug));
+
+    if (missingCategory) {
+      await safeRecordAuditEvent({
+        kind: 'audit',
+        domain: 'auth',
+        eventName: 'auth.register',
+        status: 'warning',
+        summary: `Intento de registro con categoria inexistente: ${missingCategory}`,
+        actor: context.actor,
+        requestId: context.requestId,
+        route: context.route,
+        method: context.method,
+        metadata: {
+          categorySlug: missingCategory,
+        },
+      });
+
+      return observedJson(
+        context,
+        fail('validation_error', `La categoria ${missingCategory} no existe o no esta disponible`, undefined, metaBase),
+        { status: 400, headers: rateLimitHeaders(rl) },
+      );
+    }
+
     const hashedPassword = await bcrypt.hash(password, 12);
     const skipEmailVerification = process.env.DISABLE_EMAIL_VERIFICATION === 'true';
-    const autoCreatedCategories: Array<{
-      id: string;
-      name: string;
-      slug: string;
-      groupId: string;
-      parentCategoryId: string | null;
-      active: boolean;
-    }> = [];
 
     const result = await prisma.$transaction(async (tx) => {
       const user = await tx.user.create({
@@ -220,7 +363,8 @@ export async function POST(request: NextRequest) {
           password: hashedPassword,
           firstName,
           lastName,
-          dni: dni.trim(),
+          gender: gender || null,
+          dni: normalizedDni,
           phone: phone || null,
           birthDate: birthDate ? new Date(birthDate) : null,
           location: location || null,
@@ -233,7 +377,7 @@ export async function POST(request: NextRequest) {
       if (bio || experienceYears || (services && services.length > 0) || professionalGroup) {
         const groupToUse = professionalGroup || 'oficios';
 
-        const categoryGroupRecord = await tx.categoryGroup.upsert({
+        await tx.categoryGroup.upsert({
           where: { id: groupToUse },
           update: {},
           create: {
@@ -248,51 +392,25 @@ export async function POST(request: NextRequest) {
           | undefined = undefined;
 
         if (services && services.length > 0) {
-          servicesCreateData = await Promise.all(
-            services.map(async (s: ServiceFormInput) => {
-              let category = await tx.category.findUnique({
-                where: { slug: s.categoryId },
-                select: { id: true },
-              });
-              if (!category) {
-                const fallbackName = String(s.categoryId)
-                  .replace(/-/g, ' ')
-                  .replace(/\b\w/g, (m: string) => m.toUpperCase());
-                const created = await tx.category.create({
-                  data: {
-                    name: fallbackName,
-                    description: '',
-                    slug: s.categoryId,
-                    active: true,
-                    groupId: categoryGroupRecord.id,
-                  },
-                  select: {
-                    id: true,
-                    name: true,
-                    slug: true,
-                    groupId: true,
-                    parentCategoryId: true,
-                    active: true,
-                  },
-                });
-                autoCreatedCategories.push(created);
-                category = created;
-              }
-              return {
-                categoryId: category.id,
-                title: s.title,
-                description: s.description,
-                categoryGroup: professionalGroup || undefined,
-              };
-            }),
-          );
+          servicesCreateData = services.map((s: ServiceFormInput) => {
+            const category = categoryBySlug.get(s.categoryId.trim());
+            if (!category) {
+              throw new Error('Categoria no encontrada');
+            }
+            return {
+              categoryId: category.id,
+              title: s.title,
+              description: s.description,
+              categoryGroup: professionalGroup || undefined,
+            };
+          });
         }
 
         professional = await tx.professional.create({
           data: {
             userId: user.id,
             bio: bio || '',
-            experienceYears: typeof experienceYears === 'number' ? experienceYears : 0,
+            experienceYears: normalizedExperienceYears,
             requiresDocumentation: true,
             professionalGroup: professionalGroup || null,
             location: location || null,
@@ -341,6 +459,29 @@ export async function POST(request: NextRequest) {
     const { password: _dbPassword, ...userWithoutPassword } = result.user as PrismaUser;
     void _dbPassword;
 
+    let emailVerificationQueued = false;
+
+    if (!skipEmailVerification && result.token) {
+      try {
+        const emailJob = await enqueueEmailVerify({
+          userId: userWithoutPassword.id,
+          token: result.token,
+          email: userWithoutPassword.email,
+          firstName: userWithoutPassword.firstName || undefined,
+          observability: {
+            requestId: context.requestId,
+            actor: {
+              ...context.actor,
+              id: userWithoutPassword.id,
+            },
+          },
+        });
+        emailVerificationQueued = Boolean(emailJob);
+      } catch (e) {
+        console.error('Error encolando correo de verificacion (v1):', e);
+      }
+    }
+
     await safeRecordAuditEvent({
       kind: 'audit',
       domain: 'auth',
@@ -363,63 +504,13 @@ export async function POST(request: NextRequest) {
           professional: result.professional,
           servicesCount: payload.services?.length || 0,
           skipEmailVerification,
+          emailVerificationQueued,
         }),
       ),
       metadata: {
         hasProfessional: Boolean(result.professional),
       },
     });
-
-    for (const category of autoCreatedCategories.reduce<Array<typeof autoCreatedCategories[number]>>(
-      (acc, current) => {
-        if (acc.some((item) => item.slug === current.slug)) {
-          return acc;
-        }
-        acc.push(current);
-        return acc;
-      },
-      [],
-    )) {
-      await safeRecordAuditEvent({
-        kind: 'audit',
-        domain: 'services.catalog',
-        eventName: 'category.auto_created',
-        status: 'success',
-        summary: `Categoria ${category.slug} creada automaticamente durante registro`,
-        actor: {
-          ...context.actor,
-          id: userWithoutPassword.id,
-        },
-        requestId: context.requestId,
-        route: context.route,
-        method: context.method,
-        entityType: 'category',
-        entityId: category.id,
-        changes: buildChanges(null, category),
-        metadata: {
-          source: 'auth_register',
-          userId: userWithoutPassword.id,
-        },
-      });
-    }
-
-    try {
-      await enqueueEmailVerify({
-        userId: userWithoutPassword.id,
-        token: result.token,
-        email: userWithoutPassword.email,
-        firstName: userWithoutPassword.firstName || undefined,
-        observability: {
-          requestId: context.requestId,
-          actor: {
-            ...context.actor,
-            id: userWithoutPassword.id,
-          },
-        },
-      });
-    } catch (e) {
-      console.error('Error encolando correo de verificacion (v1):', e);
-    }
 
     if (result.professional) {
       enqueueSlackAlert(
@@ -469,7 +560,7 @@ export async function POST(request: NextRequest) {
     }
 
     const devVerifyUrl =
-      !skipEmailVerification && result.token && process.env.NODE_ENV !== 'production'
+      emailVerificationQueued && result.token && process.env.NODE_ENV !== 'production'
         ? (() => {
             const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || process.env.VERCEL_URL || '';
             const origin = baseUrl.startsWith('http') ? baseUrl : `https://${baseUrl}`;
@@ -478,16 +569,22 @@ export async function POST(request: NextRequest) {
             )}`;
           })()
         : undefined;
+    const message = skipEmailVerification
+      ? 'Usuario registrado exitosamente. La verificacion por email esta deshabilitada temporalmente.'
+      : emailVerificationQueued
+        ? 'Usuario registrado. Te enviamos un correo para confirmar la cuenta.'
+        : 'Usuario registrado. No pudimos enviar el correo de verificacion; solicita un nuevo enlace desde la pantalla de verificacion.';
 
     return observedJson(
       context,
       ok(
         {
-          message: skipEmailVerification
-            ? 'Usuario registrado exitosamente.'
-            : 'Usuario registrado. Te enviamos un correo para confirmar la cuenta.',
+          message,
           user: userWithoutPassword,
           professional: result.professional,
+          emailVerificationRequired: !skipEmailVerification,
+          emailVerificationQueued,
+          emailVerificationDisabled: skipEmailVerification,
           ...(devVerifyUrl ? { devVerifyUrl } : {}),
         },
         metaBase,

--- a/src/app/auth/registro/_components/validate.ts
+++ b/src/app/auth/registro/_components/validate.ts
@@ -54,8 +54,10 @@ export type Step2Data = {
 export function validateRegisterStep2(data: Step2Data): Record<string, string> {
   const errors: Record<string, string> = {}
   if (!data.bio?.toString().trim()) errors.bio = 'La descripción profesional es requerida'
-  const years = Number(data.experienceYears)
-  if (!Number.isFinite(years) || years < 0) errors.experienceYears = 'Los años de experiencia son requeridos'
+  if (data.experienceYears !== '') {
+    const years = Number(data.experienceYears)
+    if (!Number.isFinite(years) || years < 0) errors.experienceYears = 'Los años de experiencia deben ser 0 o más'
+  }
   if (!data.professionalGroup) errors.professionalGroup = 'Debes elegir si ofreces Oficios o Profesiones'
   return errors
 }

--- a/src/app/auth/registro/page.tsx
+++ b/src/app/auth/registro/page.tsx
@@ -407,8 +407,11 @@ export default function RegistroPage() {
     const newErrors: {[key: string]: string} = {};
 
     if (!formData.bio.trim()) newErrors.bio = "La descripción profesional es requerida";
-    if (!formData.experienceYears || parseInt(formData.experienceYears) < 0) {
-      newErrors.experienceYears = "Los años de experiencia son requeridos";
+    if (
+      formData.experienceYears &&
+      (!Number.isFinite(Number(formData.experienceYears)) || Number(formData.experienceYears) < 0)
+    ) {
+      newErrors.experienceYears = "Los años de experiencia deben ser 0 o más";
     }
     if (!formData.professionalGroup) {
       newErrors.professionalGroup = "Debes elegir si ofreces Oficios o Profesiones";
@@ -539,6 +542,7 @@ export default function RegistroPage() {
         password: formData.password,
         firstName: formData.firstName,
         lastName: formData.lastName,
+        gender: formData.gender,
         dni: formData.dni.trim(),
         phone: normalizeWhatsAppNumber(formData.whatsapp) ?? undefined, // Usar WhatsApp como teléfono
         birthDate: formData.birthDate,
@@ -1007,7 +1011,7 @@ export default function RegistroPage() {
 
       <div>
         <Label htmlFor="experience" className="text-sm font-semibold text-gray-700">
-          Años de experiencia *
+          Años de experiencia
         </Label>
         <div className="relative mt-1">
           <Award className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -137,6 +137,7 @@ export interface RegisterFormData {
   password: string;
   confirmPassword?: string;
   dni?: string; // Documento Nacional de Identidad (obligatorio)
+  gender?: string;
   phone?: string; // Se asocia al WhatsApp del paso 2
   birthDate?: string;
   location?: string;
@@ -218,4 +219,3 @@ export interface Training {
   imageUrl?: string;
   tags?: string[];
 }
-

--- a/tests/integration/api/auth/register-v1.test.ts
+++ b/tests/integration/api/auth/register-v1.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest, NextResponse } from 'next/server';
+import { POST } from '@/app/api/v1/auth/register/route';
+
+const hoisted = vi.hoisted(() => ({
+  prismaMock: {
+    user: { findUnique: vi.fn() },
+    category: { findMany: vi.fn() },
+    $transaction: vi.fn(),
+  },
+  tx: {
+    user: { create: vi.fn() },
+    categoryGroup: { upsert: vi.fn() },
+    category: { findUnique: vi.fn(), create: vi.fn() },
+    professional: { create: vi.fn() },
+    verificationToken: { create: vi.fn() },
+  },
+  enqueueEmailVerifyMock: vi.fn(),
+  enqueueSlackAlertMock: vi.fn(),
+  safeRecordAuditEventMock: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({ prisma: hoisted.prismaMock }));
+vi.mock('@/jobs/email.producer', () => ({ enqueueEmailVerify: hoisted.enqueueEmailVerifyMock }));
+vi.mock('@/jobs/slack.producer', () => ({ enqueueSlackAlert: hoisted.enqueueSlackAlertMock }));
+vi.mock('@/lib/observability/audit', () => ({
+  buildChanges: vi.fn(() => ({})),
+  safeRecordAuditEvent: hoisted.safeRecordAuditEventMock,
+  observedJson: vi.fn(async (_context: unknown, payload: unknown, init?: ResponseInit) =>
+    NextResponse.json(payload, init)
+  ),
+}));
+
+function makeRequest(body: unknown) {
+  return new NextRequest(
+    new Request('http://localhost/api/v1/auth/register', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-real-ip': '10.0.0.10',
+      },
+      body: JSON.stringify(body),
+    })
+  );
+}
+
+const validPayload = {
+  email: 'ana@example.com',
+  password: 'secret123',
+  firstName: 'Ana',
+  lastName: 'Perez',
+  dni: '12345678',
+  birthDate: '1990-01-01',
+  location: 'Ceres',
+  whatsapp: '349112345678',
+  bio: 'Profesional con experiencia en servicios domiciliarios.',
+  professionalGroup: 'oficios',
+  serviceLocations: ['Ceres'],
+  services: [{ categoryId: 'plomero', title: 'Plomeria', description: 'Instalaciones y reparaciones.' }],
+};
+
+describe('POST /api/v1/auth/register', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'http://localhost:3000');
+    vi.stubEnv('DISABLE_EMAIL_VERIFICATION', 'false');
+
+    hoisted.prismaMock.user.findUnique.mockResolvedValue(null);
+    hoisted.prismaMock.category.findMany.mockResolvedValue([{ id: 'cat1', slug: 'plomero' }]);
+    hoisted.tx.user.create.mockResolvedValue({
+      id: 'u1',
+      email: 'ana@example.com',
+      firstName: 'Ana',
+      lastName: 'Perez',
+      dni: '12345678',
+      verified: false,
+      password: 'hashed',
+    });
+    hoisted.tx.categoryGroup.upsert.mockResolvedValue({ id: 'oficios' });
+    hoisted.tx.category.findUnique.mockResolvedValue({ id: 'cat1' });
+    hoisted.tx.category.create.mockResolvedValue({
+      id: 'cat2',
+      name: 'Nueva',
+      slug: 'nueva',
+      groupId: 'oficios',
+      parentCategoryId: null,
+      active: true,
+    });
+    hoisted.tx.professional.create.mockResolvedValue({
+      id: 'p1',
+      status: 'pending',
+      professionalGroup: 'oficios',
+    });
+    hoisted.tx.verificationToken.create.mockResolvedValue({ id: 'token1' });
+    hoisted.prismaMock.$transaction.mockImplementation(async (cb: (tx: typeof hoisted.tx) => Promise<unknown>) =>
+      cb(hoisted.tx)
+    );
+    hoisted.enqueueEmailVerifyMock.mockResolvedValue({ id: 'job1' });
+    hoisted.enqueueSlackAlertMock.mockResolvedValue(null);
+    hoisted.safeRecordAuditEventMock.mockResolvedValue(undefined);
+  });
+
+  it('rechaza email con formato invalido antes de consultar la base', async () => {
+    const res = await POST(makeRequest({ ...validPayload, email: 'email-invalido' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('validation_error');
+    expect(json.error.message).toContain('email');
+    expect(hoisted.prismaMock.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('rechaza registros de menores de edad', async () => {
+    const res = await POST(makeRequest({ ...validPayload, birthDate: '2015-01-01' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('validation_error');
+    expect(json.error.message).toContain('mayor de 18');
+    expect(hoisted.prismaMock.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('rechaza un perfil profesional sin WhatsApp valido', async () => {
+    const res = await POST(makeRequest({ ...validPayload, whatsapp: '15 123' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('validation_error');
+    expect(json.error.message).toContain('WhatsApp');
+    expect(hoisted.prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('rechaza un grupo profesional invalido y servicios vacios', async () => {
+    const res = await POST(
+      makeRequest({ ...validPayload, professionalGroup: 'hobbies', services: [] })
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('validation_error');
+    expect(json.error.message).toContain('grupo profesional');
+    expect(hoisted.prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('acepta experienceYears ausente y guarda 0', async () => {
+    const { experienceYears: _unused, ...payloadWithoutExperience } = {
+      ...validPayload,
+      experienceYears: 7,
+    };
+    void _unused;
+
+    const res = await POST(makeRequest(payloadWithoutExperience));
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(hoisted.tx.professional.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ experienceYears: 0 }),
+      })
+    );
+  });
+
+  it('rechaza servicios con categorias inexistentes sin crear categorias automaticamente', async () => {
+    hoisted.prismaMock.category.findMany.mockResolvedValueOnce([]);
+
+    const res = await POST(makeRequest(validPayload));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('validation_error');
+    expect(json.error.message).toContain('categoria');
+    expect(hoisted.prismaMock.$transaction).not.toHaveBeenCalled();
+    expect(hoisted.tx.category.create).not.toHaveBeenCalled();
+  });
+
+  it('no informa que envio correo cuando no pudo encolar la verificacion', async () => {
+    hoisted.enqueueEmailVerifyMock.mockResolvedValueOnce(null);
+
+    const res = await POST(makeRequest(validPayload));
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(json.data.message).not.toContain('Te enviamos');
+    expect(json.data.emailVerificationQueued).toBe(false);
+  });
+
+  it('no informa envio de correo cuando la verificacion esta deshabilitada', async () => {
+    vi.stubEnv('DISABLE_EMAIL_VERIFICATION', 'true');
+
+    const res = await POST(makeRequest(validPayload));
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(json.data.message).not.toContain('Te enviamos');
+    expect(json.data.emailVerificationDisabled).toBe(true);
+    expect(json.data.emailVerificationQueued).toBe(false);
+    expect(hoisted.enqueueEmailVerifyMock).not.toHaveBeenCalled();
+  });
+
+  it('persiste el genero enviado por registro manual', async () => {
+    const res = await POST(makeRequest({ ...validPayload, gender: 'female' }));
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(hoisted.tx.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ gender: 'female' }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Qué cambia
- 

## Cómo se probó
- [x] Unit
- [x] Integration
- [x] E2E
Comandos: `npm run test`, `npm run test:e2e`

## Checklist
- [x] Typecheck / Lint ok
- [ ] Estados vacíos/errores cubiertos
- [ ] Mensajes accesibles (roles/labels)
- [ ] Issue linkeado: #123