### PR TITLE
feat: endpoint de pendientes para reminders ops

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,3 +61,4 @@ tests
 *.test.tsx
 *.spec.ts
 *.spec.tsx
+/output

--- a/docs/REMINDERS_PENDING_API_SPEC.md
+++ b/docs/REMINDERS_PENDING_API_SPEC.md
@@ -1,0 +1,162 @@
+# API de pendientes de recordatorios
+
+## Objetivo
+
+Exponer por API, desde `plataforma-servicios-ceres`, los candidatos pendientes de recordatorio para que `ceres-api` los consuma y centralice el envio de emails (`/api/v1/ops/jobs/email`).
+
+Este endpoint **no envia emails**. Solo calcula y entrega pendientes segun reglas de negocio de la plataforma.
+
+## Endpoint
+
+- `GET /api/v1/ops/reminders/pending`
+
+## Autenticacion
+
+Mismo patron de endpoints operativos:
+
+- Header `x-api-key` obligatorio.
+- Key valida: `OPS_API_KEY` o `ADMIN_API_KEY` (fallback ya usado en este proyecto).
+- Respuesta `401` si falta o es invalida.
+
+## Query params
+
+- `type` (required):  
+  - `verify_account`
+  - `missing_criminal_record`
+- `window` (required):  
+  - `d1` (24h)
+  - `d3` (72h)
+  - `d7` (7 dias)
+- `limit` (optional): default `100`, max `1000`
+- `cursor` (optional): paginacion basada en `createdAt`/`id`
+
+## Reglas de negocio
+
+## 1) `type=verify_account`
+
+Incluir usuarios que cumplan:
+
+- `user.verified = false`
+- email valido/no vacio
+- edad de cuenta dentro o por encima de la ventana pedida (`window`)
+- aun no enviados recordatorios para esa ventana (idempotencia por key)
+
+Excluir:
+
+- usuarios ya verificados
+- usuarios sin email valido
+
+## 2) `type=missing_criminal_record`
+
+Incluir profesionales que cumplan:
+
+- `professional.requiresDocumentation = true`
+- documento penal no cargado (`criminalRecordObjectKey` ausente)
+- email de usuario asociado valido
+- edad de registro dentro o por encima de la ventana pedida (`window`)
+- aun no enviados recordatorios para esa ventana (idempotencia por key)
+
+Excluir:
+
+- profesionales que ya subieron certificado penal
+- profesionales sin email de usuario
+
+## Contrato de respuesta
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "entityType": "user",
+      "entityId": "usr_123",
+      "email": "usuario@dominio.com",
+      "firstName": "Juan",
+      "templateKey": "services.reminder_verify_account",
+      "payload": {
+        "verificationUrl": "https://ceres.gob.ar/auth/verify?token=abc&email=usuario%40dominio.com"
+      },
+      "idempotencyKey": "reminder.verify_email:usr_123:d1",
+      "source": "plataforma-servicios-ceres",
+      "domain": "auth.email",
+      "summary": "Recordatorio de verificacion de cuenta (d1)"
+    }
+  ],
+  "pagination": {
+    "nextCursor": null,
+    "limit": 100
+  }
+}
+```
+
+## Campos por item
+
+- `entityType`: `user` | `professional`
+- `entityId`: id de entidad de negocio
+- `email`: destinatario final (sin enmascarar, backend la enmascara al loguear)
+- `firstName`: opcional
+- `templateKey`:
+  - `services.reminder_verify_account`
+  - `services.reminder_missing_criminal_record`
+- `payload`: datos para render de template (urls y campos dinamicos)
+- `idempotencyKey`: clave unica por entidad+ventana
+- `source`: `plataforma-servicios-ceres`
+- `domain`: `auth.email` | `professional.documentation`
+- `summary`: descripcion legible para timeline
+
+## Errores
+
+- `400` parametros invalidos (`type/window/limit`)
+- `401` api key invalida o ausente
+- `500` error interno
+
+Formato estandar envelope:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "validation_error",
+    "message": "Parametro type invalido"
+  },
+  "meta": {
+    "requestId": "..."
+  }
+}
+```
+
+## Idempotencia y deduplicacion
+
+La plataforma devuelve `idempotencyKey` estable por ventana:
+
+- `reminder.verify_email:<userId>:d1|d3|d7`
+- `reminder.criminal_record:<professionalId>:d1|d3|d7`
+
+`ceres-api` usa esa key en su cola (`ops:email:idempotency:*`) para evitar duplicados.
+
+## Observabilidad esperada en `ceres-api`
+
+Eventos por template:
+
+- `.requested`
+- `.sent`
+- `.failed`
+- `.skipped`
+
+## Ejemplos de consumo (backend)
+
+```bash
+curl -s -H "x-api-key: <OPS_API_KEY>" \
+  "https://plataforma.ceres.gob.ar/api/v1/ops/reminders/pending?type=verify_account&window=d1&limit=200"
+```
+
+```bash
+curl -s -H "x-api-key: <OPS_API_KEY>" \
+  "https://plataforma.ceres.gob.ar/api/v1/ops/reminders/pending?type=missing_criminal_record&window=d3&cursor=<token>"
+```
+
+## No objetivos
+
+- No enviar email directo desde plataforma.
+- No agregar provider logic (Resend/SMTP) en este endpoint.
+- No introducir nuevas variables de entorno salvo que sea estrictamente necesario en implementacion posterior.

--- a/src/app/api/v1/ops/reminders/pending/route.ts
+++ b/src/app/api/v1/ops/reminders/pending/route.ts
@@ -1,0 +1,400 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fail, ok, requestMeta } from '@/lib/api-response';
+import { prisma } from '@/lib/prisma';
+import { getAbsoluteUrl } from '@/lib/seo';
+import { observedJson, safeRecordAuditEvent } from '@/lib/observability/audit';
+import {
+  createRequestObservationContext,
+  createSystemActor,
+  resolveAdminActor,
+} from '@/lib/observability/context';
+
+type ReminderType = 'verify_account' | 'missing_criminal_record';
+type ReminderWindow = 'd1' | 'd3' | 'd7';
+
+type PendingReminderItem = {
+  entityType: 'user' | 'professional';
+  entityId: string;
+  email: string;
+  firstName?: string;
+  templateKey:
+    | 'services.reminder_verify_account'
+    | 'services.reminder_missing_criminal_record';
+  payload: Record<string, unknown>;
+  idempotencyKey: string;
+  source: 'plataforma-servicios-ceres';
+  domain: 'auth.email' | 'professional.documentation';
+  summary: string;
+};
+
+const MAX_LIMIT = 1000;
+const DEFAULT_LIMIT = 100;
+
+function getApiKey(request: NextRequest) {
+  return (
+    request.headers.get('x-api-key') ||
+    request.headers.get('authorization')?.replace('Bearer ', '')
+  );
+}
+
+function isAuthorized(apiKey: string | null) {
+  if (!apiKey) {
+    return false;
+  }
+
+  const allowed = [process.env.OPS_API_KEY, process.env.ADMIN_API_KEY].filter(
+    (v): v is string => Boolean(v),
+  );
+  return allowed.includes(apiKey);
+}
+
+function parseType(value: string | null): ReminderType | null {
+  if (value === 'verify_account' || value === 'missing_criminal_record') {
+    return value;
+  }
+  return null;
+}
+
+function parseWindow(value: string | null): ReminderWindow | null {
+  if (value === 'd1' || value === 'd3' || value === 'd7') {
+    return value;
+  }
+  return null;
+}
+
+function parseLimit(value: string | null): number {
+  const parsed = Number.parseInt(value || '', 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(parsed, MAX_LIMIT);
+}
+
+function getWindowMs(window: ReminderWindow): number {
+  switch (window) {
+    case 'd1':
+      return 24 * 60 * 60 * 1000;
+    case 'd3':
+      return 3 * 24 * 60 * 60 * 1000;
+    case 'd7':
+      return 7 * 24 * 60 * 60 * 1000;
+  }
+}
+
+function encodeCursor(createdAt: Date, id: string): string {
+  return Buffer.from(
+    JSON.stringify({
+      createdAt: createdAt.toISOString(),
+      id,
+    }),
+    'utf8',
+  ).toString('base64');
+}
+
+function decodeCursor(cursor: string | null): { createdAt: Date; id: string } | null {
+  if (!cursor) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64').toString('utf8')) as {
+      createdAt?: string;
+      id?: string;
+    };
+    if (!parsed.createdAt || !parsed.id) {
+      return null;
+    }
+    const createdAt = new Date(parsed.createdAt);
+    if (Number.isNaN(createdAt.getTime())) {
+      return null;
+    }
+    return { createdAt, id: parsed.id };
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const meta = requestMeta(request);
+  const context = createRequestObservationContext(request, {
+    route: '/api/v1/ops/reminders/pending',
+    requestId: meta.requestId,
+    actor: createSystemActor('ops-reminders-pending'),
+  });
+  const apiKey = getApiKey(request);
+
+  if (!apiKey) {
+    await safeRecordAuditEvent({
+      kind: 'audit',
+      domain: 'ops.reminders',
+      eventName: 'ops.reminders_pending.fetch',
+      status: 'warning',
+      summary: 'Consulta de pendientes rechazada por API key ausente',
+      actor: context.actor,
+      requestId: context.requestId,
+      route: context.route,
+      method: context.method,
+    });
+    return observedJson(
+      context,
+      fail('unauthorized', 'API key requerida', undefined, meta),
+      { status: 401 },
+    );
+  }
+
+  if (!isAuthorized(apiKey)) {
+    await safeRecordAuditEvent({
+      kind: 'audit',
+      domain: 'ops.reminders',
+      eventName: 'ops.reminders_pending.fetch',
+      status: 'warning',
+      summary: 'Consulta de pendientes rechazada por API key invalida',
+      actor: context.actor,
+      requestId: context.requestId,
+      route: context.route,
+      method: context.method,
+    });
+    return observedJson(
+      context,
+      fail('forbidden', 'API key invalida', undefined, meta),
+      { status: 403 },
+    );
+  }
+  context.actor = resolveAdminActor(request, context.requestId);
+
+  const searchParams = request.nextUrl.searchParams;
+  const type = parseType(searchParams.get('type'));
+  const window = parseWindow(searchParams.get('window'));
+  const limit = parseLimit(searchParams.get('limit'));
+  const cursor = decodeCursor(searchParams.get('cursor'));
+
+  if (!type) {
+    await safeRecordAuditEvent({
+      kind: 'audit',
+      domain: 'ops.reminders',
+      eventName: 'ops.reminders_pending.fetch',
+      status: 'warning',
+      summary: 'Consulta de pendientes con parametro type invalido',
+      actor: context.actor,
+      requestId: context.requestId,
+      route: context.route,
+      method: context.method,
+      metadata: {
+        type: searchParams.get('type'),
+        window: searchParams.get('window'),
+      },
+    });
+    return observedJson(
+      context,
+      fail(
+        'validation_error',
+        'Parametro type invalido. Valores permitidos: verify_account | missing_criminal_record',
+        undefined,
+        meta,
+      ),
+      { status: 400 },
+    );
+  }
+
+  if (!window) {
+    await safeRecordAuditEvent({
+      kind: 'audit',
+      domain: 'ops.reminders',
+      eventName: 'ops.reminders_pending.fetch',
+      status: 'warning',
+      summary: 'Consulta de pendientes con parametro window invalido',
+      actor: context.actor,
+      requestId: context.requestId,
+      route: context.route,
+      method: context.method,
+      metadata: {
+        type,
+        window: searchParams.get('window'),
+      },
+    });
+    return observedJson(
+      context,
+      fail(
+        'validation_error',
+        'Parametro window invalido. Valores permitidos: d1 | d3 | d7',
+        undefined,
+        meta,
+      ),
+      { status: 400 },
+    );
+  }
+
+  const cutoff = new Date(Date.now() - getWindowMs(window));
+
+  try {
+    let data: PendingReminderItem[] = [];
+    let nextCursor: string | null = null;
+
+    if (type === 'verify_account') {
+      const users = await prisma.user.findMany({
+        where: {
+          verified: false,
+          createdAt: { lte: cutoff },
+          NOT: { email: '' },
+          ...(cursor
+            ? {
+                OR: [
+                  { createdAt: { lt: cursor.createdAt } },
+                  { createdAt: cursor.createdAt, id: { lt: cursor.id } },
+                ],
+              }
+            : {}),
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: limit + 1,
+        select: {
+          id: true,
+          email: true,
+          firstName: true,
+          createdAt: true,
+        },
+      });
+
+      const hasMore = users.length > limit;
+      const page = hasMore ? users.slice(0, limit) : users;
+      const last = page.at(-1);
+      nextCursor = hasMore && last ? encodeCursor(last.createdAt, last.id) : null;
+
+      data = page.map((user) => ({
+        entityType: 'user',
+        entityId: user.id,
+        email: user.email,
+        firstName: user.firstName || undefined,
+        templateKey: 'services.reminder_verify_account',
+        payload: {
+          firstName: user.firstName || undefined,
+          verificationUrl: getAbsoluteUrl(
+            `/auth/verify?email=${encodeURIComponent(user.email)}`,
+          ),
+        },
+        idempotencyKey: `reminder.verify_email:${user.id}:${window}`,
+        source: 'plataforma-servicios-ceres',
+        domain: 'auth.email',
+        summary: `Recordatorio de verificacion de cuenta (${window}) para usuario ${user.id}`,
+      }));
+    } else {
+      const professionals = await prisma.professional.findMany({
+        where: {
+          requiresDocumentation: true,
+          createdAt: { lte: cutoff },
+          user: {
+            email: { not: '' },
+          },
+          OR: [
+            { documentation: null },
+            {
+              documentation: {
+                is: { criminalRecordObjectKey: null },
+              },
+            },
+          ],
+          ...(cursor
+            ? {
+                OR: [
+                  { createdAt: { lt: cursor.createdAt } },
+                  { createdAt: cursor.createdAt, id: { lt: cursor.id } },
+                ],
+              }
+            : {}),
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        take: limit + 1,
+        select: {
+          id: true,
+          createdAt: true,
+          user: {
+            select: {
+              email: true,
+              firstName: true,
+            },
+          },
+        },
+      });
+
+      const hasMore = professionals.length > limit;
+      const page = hasMore ? professionals.slice(0, limit) : professionals;
+      const last = page.at(-1);
+      nextCursor = hasMore && last ? encodeCursor(last.createdAt, last.id) : null;
+
+      data = page.map((professional) => ({
+        entityType: 'professional',
+        entityId: professional.id,
+        email: professional.user.email,
+        firstName: professional.user.firstName || undefined,
+        templateKey: 'services.reminder_missing_criminal_record',
+        payload: {
+          firstName: professional.user.firstName || undefined,
+          documentsUrl: getAbsoluteUrl('/dashboard/settings'),
+        },
+        idempotencyKey: `reminder.criminal_record:${professional.id}:${window}`,
+        source: 'plataforma-servicios-ceres',
+        domain: 'professional.documentation',
+        summary: `Recordatorio de certificado penal pendiente (${window}) para profesional ${professional.id}`,
+      }));
+    }
+
+    await safeRecordAuditEvent({
+      kind: 'audit',
+      domain: 'ops.reminders',
+      eventName: 'ops.reminders_pending.fetch',
+      status: 'success',
+      summary: `Pendientes de recordatorios obtenidos (${type}/${window})`,
+      actor: context.actor,
+      requestId: context.requestId,
+      route: context.route,
+      method: context.method,
+      metadata: {
+        type,
+        window,
+        limit,
+        cursorPresent: Boolean(searchParams.get('cursor')),
+        itemsFetched: data.length,
+        nextCursorPresent: Boolean(nextCursor),
+      },
+    });
+
+    return observedJson(
+      context,
+      {
+        success: true,
+        data,
+        pagination: {
+          nextCursor,
+          limit,
+        },
+        meta,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error('Error obteniendo pendientes de recordatorios:', error);
+    await safeRecordAuditEvent({
+      kind: 'audit',
+      domain: 'ops.reminders',
+      eventName: 'ops.reminders_pending.fetch',
+      status: 'failure',
+      summary: 'Error al obtener pendientes de recordatorios',
+      actor: context.actor,
+      requestId: context.requestId,
+      route: context.route,
+      method: context.method,
+      metadata: {
+        type,
+        window,
+        limit,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+    });
+    return observedJson(
+      context,
+      fail('server_error', 'Error al obtener pendientes de recordatorios', undefined, meta),
+      { status: 500 },
+    );
+  }
+}
+

--- a/src/app/auth/registro/page.tsx
+++ b/src/app/auth/registro/page.tsx
@@ -1587,6 +1587,17 @@ export default function RegistroPage() {
           El certificado de antecedentes penales es obligatorio para que tu perfil pueda aparecer en la plataforma.
           Las referencias laborales son opcionales y se mostrarán como señal de confianza en tu perfil.
         </p>
+        <p className="text-sm text-gray-700 mt-3">
+          Para obtener el certificado de antecedentes penales:{' '}
+          <a
+            href="https://www.argentina.gob.ar/justicia/reincidencia/antecedentespenales"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#006F4B] underline break-all"
+          >
+            https://www.argentina.gob.ar/justicia/reincidencia/antecedentespenales
+          </a>
+        </p>
       </div>
 
       <ProfessionalDocumentationFields

--- a/src/app/auth/verify/page.tsx
+++ b/src/app/auth/verify/page.tsx
@@ -17,10 +17,10 @@ export default function VerifyPage() {
       try {
         await verifyAccount(token, email)
         setStatus('success')
-        setMessage('Â¡Tu cuenta fue verificada! Ya podÃ©s iniciar sesiÃ³n.')
+        setMessage('¡Tu cuenta fue verificada! Ya podés iniciar sesión.')
       } catch (error: unknown) {
         setStatus('error')
-        setMessage(getErrorMessage(error, 'El enlace no es vÃ¡lido o expirÃ³.'))
+        setMessage(getErrorMessage(error, 'El enlace no es válido o expiró.'))
       }
     }
 
@@ -29,7 +29,7 @@ export default function VerifyPage() {
 
   return (
     <div className="max-w-xl mx-auto py-20 px-4">
-      <h1 className="text-2xl font-semibold mb-4">ConfirmaciÃ³n de cuenta</h1>
+      <h1 className="text-2xl font-semibold mb-4">Confirmación de cuenta</h1>
       <p className={status === 'error' ? 'text-red-600' : status === 'success' ? 'text-green-700' : ''}>{message}</p>
     </div>
   )

--- a/tests/integration/api/ops/reminders-pending.test.ts
+++ b/tests/integration/api/ops/reminders-pending.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/v1/ops/reminders/pending/route';
+
+const hoisted = vi.hoisted(() => ({
+  prismaMock: {
+    user: { findMany: vi.fn() },
+    professional: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/prisma', () => ({ prisma: hoisted.prismaMock }));
+
+function makeRequest(query: string, apiKey?: string) {
+  const headers: HeadersInit = {};
+  if (apiKey) {
+    headers['x-api-key'] = apiKey;
+  }
+
+  return new NextRequest(
+    new Request(`http://localhost/api/v1/ops/reminders/pending${query}`, {
+      method: 'GET',
+      headers,
+    }),
+  );
+}
+
+describe('GET /api/v1/ops/reminders/pending', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('OPS_API_KEY', 'ops-key');
+    vi.stubEnv('ADMIN_API_KEY', 'admin-key');
+  });
+
+  it('requiere api key', async () => {
+    const res = await GET(makeRequest('?type=verify_account&window=d1'));
+    const json = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('unauthorized');
+  });
+
+  it('valida parametro type', async () => {
+    const res = await GET(makeRequest('?type=otro&window=d1', 'ops-key'));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error.code).toBe('validation_error');
+  });
+
+  it('devuelve pendientes de verificacion de cuenta', async () => {
+    hoisted.prismaMock.user.findMany.mockResolvedValueOnce([
+      {
+        id: 'u1',
+        email: 'ana@example.com',
+        firstName: 'Ana',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    ]);
+
+    const res = await GET(
+      makeRequest('?type=verify_account&window=d1&limit=10', 'ops-key'),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data).toHaveLength(1);
+    expect(json.data[0]).toMatchObject({
+      entityType: 'user',
+      entityId: 'u1',
+      templateKey: 'services.reminder_verify_account',
+      idempotencyKey: 'reminder.verify_email:u1:d1',
+      source: 'plataforma-servicios-ceres',
+      domain: 'auth.email',
+    });
+    expect(json.pagination.limit).toBe(10);
+  });
+
+  it('devuelve pendientes de certificado penal', async () => {
+    hoisted.prismaMock.professional.findMany.mockResolvedValueOnce([
+      {
+        id: 'p1',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        user: {
+          email: 'prof@example.com',
+          firstName: 'Pro',
+        },
+      },
+    ]);
+
+    const res = await GET(
+      makeRequest('?type=missing_criminal_record&window=d3', 'admin-key'),
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data).toHaveLength(1);
+    expect(json.data[0]).toMatchObject({
+      entityType: 'professional',
+      entityId: 'p1',
+      templateKey: 'services.reminder_missing_criminal_record',
+      idempotencyKey: 'reminder.criminal_record:p1:d3',
+      source: 'plataforma-servicios-ceres',
+      domain: 'professional.documentation',
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- agrega `GET /api/v1/ops/reminders/pending` para exponer candidatos de recordatorios (`verify_account` y `missing_criminal_record`) con paginación por cursor
- incorpora observabilidad estándar en el endpoint (`observedJson` + `safeRecordAuditEvent`) para trazabilidad de success/warning/failure
- suma spec técnica en `docs/REMINDERS_PENDING_API_SPEC.md` y pruebas de integración para auth, validaciones y contrato de respuesta

## Contexto
Este cambio prepara a `plataforma-servicios-ceres` como source of truth de pendientes para que `ceres-api` consuma por API y centralice el envío de emails de reminder, sin acoplarse al esquema interno de usuarios/profesionales.

## Test plan
- [x] `npm run test:int -- tests/integration/api/ops/reminders-pending.test.ts`
- [x] validar que la ruta responde `401` sin API key
- [x] validar que responde `400` con `type/window` inválidos
- [x] validar items devueltos e `idempotencyKey` para ambos tipos de recordatorio (`verify_account` y `missing_criminal_record`)