### PR TITLE
feat: visibilidad de profesionales activos sin antecedentes + verificación manual de antecedentes

### DIFF
--- a/prisma/migrations/20260429130000_add_criminal_record_review_status/migration.sql
+++ b/prisma/migrations/20260429130000_add_criminal_record_review_status/migration.sql
@@ -1,0 +1,6 @@
+CREATE TYPE "CriminalRecordReviewStatus" AS ENUM ('pending', 'approved', 'rejected');
+
+ALTER TABLE "professional_documentation"
+  ADD COLUMN "criminalRecordStatus" "CriminalRecordReviewStatus",
+  ADD COLUMN "criminalRecordReviewedAt" TIMESTAMP(3),
+  ADD COLUMN "criminalRecordAdminNotes" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -130,6 +130,9 @@ model ProfessionalDocumentation {
   professionalId          String                       @unique
   criminalRecordObjectKey String?
   criminalRecordFileName  String?
+  criminalRecordStatus    CriminalRecordReviewStatus?
+  criminalRecordReviewedAt DateTime?
+  criminalRecordAdminNotes String?
   createdAt               DateTime                     @default(now())
   updatedAt               DateTime                     @updatedAt
   professional            Professional                 @relation(fields: [professionalId], references: [id], onDelete: Cascade)
@@ -263,6 +266,12 @@ enum BugReportSeverity {
   medium
   high
   critical
+}
+
+enum CriminalRecordReviewStatus {
+  pending
+  approved
+  rejected
 }
 
 model CategorySuggestion {

--- a/src/app/api/admin/certifications/[id]/route.ts
+++ b/src/app/api/admin/certifications/[id]/route.ts
@@ -156,38 +156,6 @@ export async function PUT(
       ),
     });
 
-    if (status === 'approved') {
-      const approvedCount = await prisma.professionalCertification.count({
-        where: {
-          professionalId: certification.professionalId,
-          status: 'approved',
-        },
-      });
-
-      if (approvedCount > 0 && !certification.professional.verified) {
-        await prisma.professional.update({
-          where: { id: certification.professionalId },
-          data: { verified: true },
-        });
-
-        await safeRecordAuditEvent({
-          kind: 'workflow',
-          domain: 'admin.certifications',
-          eventName: 'professional.verified_by_certification',
-          status: 'success',
-          summary: `Profesional ${certification.professionalId} marcado como verificado por certificacion aprobada`,
-          actor: context.actor,
-          requestId: context.requestId,
-          entityType: 'professional',
-          entityId: certification.professionalId,
-          metadata: {
-            certificationId: updated.id,
-            approvedCertifications: approvedCount,
-          },
-        });
-      }
-    }
-
     return observedJson(context, {
       success: true,
       data: updated,

--- a/src/app/api/admin/criminal-records/route.ts
+++ b/src/app/api/admin/criminal-records/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { requireAdminApiKey } from '@/lib/auth-helpers';
+
+export async function GET(request: NextRequest) {
+  const { error } = requireAdminApiKey(request);
+  if (error) return error;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get('status') as 'pending' | 'approved' | 'rejected' | null;
+    const professionalId = searchParams.get('professionalId') || undefined;
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') || '20', 10)));
+
+    const where: Prisma.ProfessionalDocumentationWhereInput = {
+      criminalRecordObjectKey: { not: null },
+    };
+
+    if (status) {
+      where.criminalRecordStatus = status;
+    }
+
+    if (professionalId) {
+      where.professionalId = professionalId;
+    }
+
+    const [total, rows] = await Promise.all([
+      prisma.professionalDocumentation.count({ where }),
+      prisma.professionalDocumentation.findMany({
+        where,
+        orderBy: [{ updatedAt: 'desc' }],
+        skip: (page - 1) * limit,
+        take: limit,
+        include: {
+          professional: {
+            select: {
+              id: true,
+              verified: true,
+              status: true,
+              user: {
+                select: {
+                  id: true,
+                  firstName: true,
+                  lastName: true,
+                  email: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+    ]);
+
+    return NextResponse.json({
+      success: true,
+      data: rows,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    });
+  } catch (routeError) {
+    console.error('Error listando antecedentes para revision:', routeError);
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'server_error',
+        message: 'Error al obtener antecedentes para revision.',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/professionals/[id]/criminal-record/route.ts
+++ b/src/app/api/admin/professionals/[id]/criminal-record/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { requireAdminApiKey } from '@/lib/auth-helpers';
+
+const VALID_STATUSES = new Set(['approved', 'rejected']);
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { error } = requireAdminApiKey(request);
+  if (error) return error;
+
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const status = body?.status;
+    const adminNotes = typeof body?.adminNotes === 'string' ? body.adminNotes.trim() : null;
+
+    if (!VALID_STATUSES.has(status)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'validation_error',
+          message: 'Estado invalido. Debe ser "approved" o "rejected".',
+        },
+        { status: 400 }
+      );
+    }
+
+    const professional = await prisma.professional.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        documentation: {
+          select: {
+            id: true,
+            criminalRecordObjectKey: true,
+          },
+        },
+      },
+    });
+
+    if (!professional) {
+      return NextResponse.json(
+        { success: false, error: 'not_found', message: 'Profesional no encontrado' },
+        { status: 404 }
+      );
+    }
+
+    if (!professional.documentation?.criminalRecordObjectKey) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'validation_error',
+          message: 'El profesional no tiene un certificado de antecedentes cargado.',
+        },
+        { status: 400 }
+      );
+    }
+
+    const reviewedAt = new Date();
+
+    const [documentation] = await prisma.$transaction([
+      prisma.professionalDocumentation.update({
+        where: { professionalId: professional.id },
+        data: {
+          criminalRecordStatus: status,
+          criminalRecordReviewedAt: reviewedAt,
+          criminalRecordAdminNotes: adminNotes || null,
+        },
+      }),
+      prisma.professional.update({
+        where: { id: professional.id },
+        data: {
+          verified: status === 'approved',
+        },
+      }),
+    ]);
+
+    return NextResponse.json({
+      success: true,
+      data: documentation,
+      message:
+        status === 'approved'
+          ? 'Antecedentes aprobados y profesional verificado.'
+          : 'Antecedentes rechazados y profesional marcado sin verificar.',
+    });
+  } catch (routeError) {
+    console.error('Error revisando antecedentes del profesional:', routeError);
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'server_error',
+        message: 'Error al revisar antecedentes del profesional.',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/auth/completar-perfil/page.tsx
+++ b/src/app/auth/completar-perfil/page.tsx
@@ -11,14 +11,19 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Button } from "@/components/ui/button";
 import { ProfessionalDocumentationFields } from "@/components/features/ProfessionalDocumentationFields";
 import { ServiceSelectionCard } from "@/components/features/ServiceSelectionCard";
-import { GROUPS, getLocations, getGenders } from "@/lib/taxonomy";
+import { CategorySuggestionModal } from "@/components/features/CategorySuggestionModal";
+import { CategoryItem } from "@/components/features/CategoryItem";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { GROUPS, getLocations, getGenders, AREAS_OFICIOS, SUBCATEGORIES_OFICIOS, SUBCATEGORIES_PROFESIONES } from "@/lib/taxonomy";
 import type { CategoryGroup, PrivateDocumentFile, ProfessionalDocumentation } from "@/types";
+import type { LucideIcon } from "lucide-react";
 import { 
   Phone, 
   MapPin, 
   Award, 
   Send, 
   ArrowLeft, 
+  ArrowRight,
   CheckCircle,
   Plus,
   Trash2,
@@ -33,7 +38,12 @@ import {
   Instagram,
   Facebook,
   Store,
-  X
+  X,
+  Wrench,
+  Snowflake,
+  Bolt,
+  Car,
+  TreePine
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -49,6 +59,7 @@ import { resolvePublicUploadUrl } from "@/lib/public-upload-url";
 import { usePublicCategoriesTree } from "@/hooks/usePublicCategoriesTree";
 import { validateProfessionalDocumentation } from "@/lib/validation/professional-documentation";
 import { trackEvent } from "@/lib/analytics/gtag";
+import { normalizeSocialHandle, validateSocialHandle } from "@/lib/social-handles";
 
 const ALLOWED_OAUTH_IMAGE_HOSTS = new Set([
   "graph.facebook.com",
@@ -116,6 +127,9 @@ export default function CompletarPerfilPage() {
   
   const [errors, setErrors] = useState<{[key: string]: string}>({});
   const [isLoading, setIsLoading] = useState(false);
+  const [isOficiosPreviewOpen, setIsOficiosPreviewOpen] = useState(false);
+  const [isProfesionesPreviewOpen, setIsProfesionesPreviewOpen] = useState(false);
+  const [selectedPreviewArea, setSelectedPreviewArea] = useState<string>("all");
 
   const areas = useMemo(
     () =>
@@ -267,6 +281,16 @@ export default function CompletarPerfilPage() {
         const newGroup = value as CategoryGroup | '';
         const resetServices = [{ areaSlug: '', categoryId: '', title: '', description: '' }];
         return { ...prev, professionalGroup: newGroup, services: resetServices };
+      }
+
+      if (
+        typeof value === "string" &&
+        (field === "instagram" || field === "facebook" || field === "linkedin")
+      ) {
+        return {
+          ...prev,
+          [field]: normalizeSocialHandle(value, field),
+        };
       }
       
       // Para WhatsApp: validar en tiempo real pero sin normalizar
@@ -469,6 +493,15 @@ export default function CompletarPerfilPage() {
     if (formData.hasPhysicalStore && !formData.physicalStoreAddress?.trim()) {
       newErrors.physicalStoreAddress = "La direccion del local es requerida si tienes un local fisico";
     }
+
+    (["instagram", "facebook", "linkedin"] as const).forEach((field) => {
+      const value = formData[field]?.trim();
+      if (!value) return;
+      const error = validateSocialHandle(value);
+      if (error) {
+        newErrors[field] = error;
+      }
+    });
 
     formData.services.forEach((service, index) => {
       if (formData.professionalGroup === "oficios" && !service.areaSlug) {
@@ -973,9 +1006,10 @@ export default function CompletarPerfilPage() {
                           value={formData.instagram}
                           onChange={(e) => handleInputChange('instagram', e.target.value)}
                           className="pl-10 rounded-lg border-2 focus:ring-4 focus:ring-green-100 focus:border-[#006F4B] transition-all duration-200 border-gray-200"
-                          placeholder="@tuusuario"
+                          placeholder="tuusuario"
                         />
                       </div>
+                      {errors.instagram && <p className="text-red-600 text-sm mt-1">{errors.instagram}</p>}
                     </div>
 
                     <div>
@@ -989,9 +1023,10 @@ export default function CompletarPerfilPage() {
                           value={formData.facebook}
                           onChange={(e) => handleInputChange('facebook', e.target.value)}
                           className="pl-10 rounded-lg border-2 focus:ring-4 focus:ring-green-100 focus:border-[#006F4B] transition-all duration-200 border-gray-200"
-                          placeholder="/tu-pagina"
+                          placeholder="tuusuario"
                         />
                       </div>
+                      {errors.facebook && <p className="text-red-600 text-sm mt-1">{errors.facebook}</p>}
                     </div>
 
                     <div>
@@ -1005,9 +1040,10 @@ export default function CompletarPerfilPage() {
                           value={formData.linkedin}
                           onChange={(e) => handleInputChange('linkedin', e.target.value)}
                           className="pl-10 rounded-lg border-2 focus:ring-4 focus:ring-green-100 focus:border-[#006F4B] transition-all duration-200 border-gray-200"
-                          placeholder="/in/tuperfil"
+                          placeholder="tuusuario"
                         />
                       </div>
+                      {errors.linkedin && <p className="text-red-600 text-sm mt-1">{errors.linkedin}</p>}
                     </div>
 
                     <div>
@@ -1218,11 +1254,124 @@ export default function CompletarPerfilPage() {
                             ? 'Trabajos manuales y técnicos por oficio (ej: plomería, electricidad, mantenimiento).'
                             : 'Profesiones colegiadas o formales (ej: enfermería, arquitectura, abogacía).'}
                         </p>
+                        <div className="mt-3">
+                          {g.id === 'oficios' ? (
+                            <button
+                              type="button"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                setIsOficiosPreviewOpen(true);
+                              }}
+                              className="inline-flex items-center text-sm font-semibold text-[#006F4B] hover:underline"
+                            >
+                              Ver categorías de oficios <ArrowRight className="ml-1 h-4 w-4" />
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                setIsProfesionesPreviewOpen(true);
+                              }}
+                              className="inline-flex items-center text-sm font-semibold text-[#006F4B] hover:underline"
+                            >
+                              Ver categorías de profesiones <ArrowRight className="ml-1 h-4 w-4" />
+                            </button>
+                          )}
+                        </div>
                       </button>
                     ))}
                   </div>
                   {errors.professionalGroup && <p className="text-red-600 text-sm mt-1">{errors.professionalGroup}</p>}
                 </div>
+
+                <Dialog open={isOficiosPreviewOpen} onOpenChange={setIsOficiosPreviewOpen}>
+                  <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+                    <DialogHeader>
+                      <DialogTitle className="text-2xl font-bold text-gray-900">
+                        Categorías de Oficios
+                      </DialogTitle>
+                    </DialogHeader>
+                    <div className="space-y-2 mt-4">
+                      {AREAS_OFICIOS.map((area) => {
+                        const isActive = selectedPreviewArea === area.slug;
+                        const subcategories = SUBCATEGORIES_OFICIOS
+                          .filter((s) => s.areaSlug === area.slug)
+                          .map((s) => ({
+                            slug: s.slug,
+                            name: s.name,
+                          }));
+
+                        const iconMap: Record<string, LucideIcon | null> = {
+                          "construccion-mantenimiento": Wrench,
+                          climatizacion: Snowflake,
+                          "servicios-electronicos": Bolt,
+                          automotores: Car,
+                          jardineria: TreePine,
+                        };
+                        const Icon = iconMap[area.slug] || Wrench;
+
+                        return (
+                          <CategoryItem
+                            key={area.id}
+                            name={area.name}
+                            slug={area.slug}
+                            icon={Icon}
+                            isActive={isActive}
+                            subcategories={subcategories}
+                            onSelect={() => setSelectedPreviewArea(area.slug)}
+                            onSelectSubcategory={() => {}}
+                          />
+                        );
+                      })}
+                    </div>
+                    <div className="mt-6 rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-center">
+                      <p className="text-sm font-medium text-emerald-900">
+                        ¿No encontrás la categoría que se adapta a tu profesión?
+                      </p>
+                      <div className="mt-3">
+                        <CategorySuggestionModal
+                          origin="completar_perfil_modal_oficios"
+                          triggerLabel="Sugerir categoría"
+                          triggerClassName="inline-flex items-center rounded-lg bg-[#006F4B] px-4 py-2 text-sm font-semibold text-white hover:bg-[#005a3d]"
+                        />
+                      </div>
+                    </div>
+                  </DialogContent>
+                </Dialog>
+
+                <Dialog open={isProfesionesPreviewOpen} onOpenChange={setIsProfesionesPreviewOpen}>
+                  <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+                    <DialogHeader>
+                      <DialogTitle className="text-2xl font-bold text-gray-900">
+                        Categorías de Profesiones
+                      </DialogTitle>
+                    </DialogHeader>
+                    <div className="space-y-2 mt-4">
+                      {SUBCATEGORIES_PROFESIONES.map((profesion) => (
+                        <div
+                          key={profesion.id}
+                          className="w-full flex items-center justify-between gap-3 px-4 py-3 text-sm font-medium rounded-lg text-left bg-gray-50 text-gray-700"
+                        >
+                          <span className="truncate">{profesion.name}</span>
+                          <ArrowRight className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="mt-6 rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-center">
+                      <p className="text-sm font-medium text-emerald-900">
+                        ¿No encontrás la categoría que se adapta a tu profesión?
+                      </p>
+                      <div className="mt-3">
+                        <CategorySuggestionModal
+                          origin="completar_perfil_modal_profesiones"
+                          triggerLabel="Sugerir categoría"
+                          triggerClassName="inline-flex items-center rounded-lg bg-[#006F4B] px-4 py-2 text-sm font-semibold text-white hover:bg-[#005a3d]"
+                        />
+                      </div>
+                    </div>
+                  </DialogContent>
+                </Dialog>
 
                 {/* Servicios */}
                 {formData.professionalGroup && (
@@ -1363,6 +1512,17 @@ export default function CompletarPerfilPage() {
                   <p className="text-gray-600">
                     El certificado de antecedentes penales es obligatorio para que tu perfil pueda aparecer en la plataforma.
                     Las referencias laborales son opcionales.
+                  </p>
+                  <p className="mt-2 text-sm text-gray-700">
+                    Para obtener el certificado de antecedentes penales:{' '}
+                    <a
+                      href="https://www.argentina.gob.ar/justicia/reincidencia/antecedentespenales"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-semibold text-[#006F4B] underline underline-offset-2"
+                    >
+                      https://www.argentina.gob.ar/justicia/reincidencia/antecedentespenales
+                    </a>
                   </p>
                 </div>
 

--- a/src/app/auth/registro/page.tsx
+++ b/src/app/auth/registro/page.tsx
@@ -14,9 +14,13 @@ import { Switch } from "@/components/ui/switch";
 import { Button } from "@/components/ui/button";
 import { ProfessionalDocumentationFields } from "@/components/features/ProfessionalDocumentationFields";
 import { ServiceSelectionCard } from "@/components/features/ServiceSelectionCard";
-import { GROUPS, getLocations, getGenders } from "@/lib/taxonomy";
+import { CategorySuggestionModal } from "@/components/features/CategorySuggestionModal";
+import { CategoryItem } from "@/components/features/CategoryItem";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { GROUPS, getLocations, getGenders, AREAS_OFICIOS, SUBCATEGORIES_OFICIOS, SUBCATEGORIES_PROFESIONES } from "@/lib/taxonomy";
 import type { CategoryGroup, PrivateDocumentFile, ProfessionalDocumentation } from "@/types";
-import { Eye, EyeOff, User, Mail, Lock, Building2, Award, Send, ArrowLeft, CheckCircle, MapPin, CircleUser, Upload, FileText, Globe, Linkedin, Instagram, Facebook, Store, IdCard } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Eye, EyeOff, User, Mail, Lock, Building2, Award, Send, ArrowLeft, ArrowRight, CheckCircle, MapPin, CircleUser, Upload, FileText, Globe, Linkedin, Instagram, Facebook, Store, IdCard, Wrench, Snowflake, Bolt, Car, TreePine } from "lucide-react";
 import WhatsAppIcon from "@/components/ui/whatsapp";
 import Link from "next/link";
 import { DateBirthPicker } from "./_components/date-birth-picker";
@@ -26,6 +30,7 @@ import { resolveStoredUploadValue, uploadRegistrationFile } from "@/lib/api/uplo
 import { uploadPrivateRegistrationDocument } from "@/lib/api/private-documents";
 import { usePublicCategoriesTree } from "@/hooks/usePublicCategoriesTree";
 import { validateProfessionalDocumentation } from "@/lib/validation/professional-documentation";
+import { normalizeSocialHandle, validateSocialHandle } from "@/lib/social-handles";
 
 // Iconos de redes sociales
 const GoogleIcon = () => (
@@ -95,6 +100,9 @@ export default function RegistroPage() {
   
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isOficiosPreviewOpen, setIsOficiosPreviewOpen] = useState(false);
+  const [isProfesionesPreviewOpen, setIsProfesionesPreviewOpen] = useState(false);
+  const [selectedPreviewArea, setSelectedPreviewArea] = useState<string>("all");
   const [errors, setErrors] = useState<{[key: string]: string}>({});
   const [isLoading, setIsLoading] = useState(false);
   const [socialLoading, setSocialLoading] = useState<string | null>(null);
@@ -264,6 +272,16 @@ export default function RegistroPage() {
         const resetServices = [{ areaSlug: '', categoryId: '', title: '', description: '', priceRange: '' }];
         return { ...prev, professionalGroup: newGroup, services: resetServices };
       }
+
+      if (
+        typeof value === "string" &&
+        (field === "instagram" || field === "facebook" || field === "linkedin")
+      ) {
+        return {
+          ...prev,
+          [field]: normalizeSocialHandle(value, field),
+        };
+      }
       
       // Para WhatsApp: NO normalizar mientras escribe, solo guardar lo que el usuario escribe
       // La normalización se hará al enviar el formulario
@@ -431,6 +449,15 @@ export default function RegistroPage() {
         newErrors.whatsapp = error;
       }
     }
+
+    (["instagram", "facebook", "linkedin"] as const).forEach((field) => {
+      const value = formData[field]?.trim();
+      if (!value) return;
+      const error = validateSocialHandle(value);
+      if (error) {
+        newErrors[field] = error;
+      }
+    });
 
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
@@ -1173,9 +1200,10 @@ export default function RegistroPage() {
                 value={formData.instagram}
                 onChange={(e) => handleInputChange('instagram', e.target.value)}
                 className="pl-10 rounded-lg border-2 focus:ring-4 focus:ring-green-100 focus:border-[#006F4B] transition-all duration-200 border-gray-200"
-                placeholder="@tuusuario"
+                placeholder="tuusuario"
               />
             </div>
+            {errors.instagram && <p className="text-red-600 text-sm mt-1">{errors.instagram}</p>}
           </div>
 
           <div>
@@ -1189,9 +1217,10 @@ export default function RegistroPage() {
                 value={formData.facebook}
                 onChange={(e) => handleInputChange('facebook', e.target.value)}
                 className="pl-10 rounded-lg border-2 focus:ring-4 focus:ring-green-100 focus:border-[#006F4B] transition-all duration-200 border-gray-200"
-                placeholder="/tu-pagina"
+                placeholder="tuusuario"
               />
             </div>
+            {errors.facebook && <p className="text-red-600 text-sm mt-1">{errors.facebook}</p>}
           </div>
 
           <div>
@@ -1205,9 +1234,10 @@ export default function RegistroPage() {
                 value={formData.linkedin}
                 onChange={(e) => handleInputChange('linkedin', e.target.value)}
                 className="pl-10 rounded-lg border-2 focus:ring-4 focus:ring-green-100 focus:border-[#006F4B] transition-all duration-200 border-gray-200"
-                placeholder="/in/tuperfil"
+                placeholder="tuusuario"
               />
             </div>
+            {errors.linkedin && <p className="text-red-600 text-sm mt-1">{errors.linkedin}</p>}
           </div>
 
           <div>
@@ -1404,10 +1434,123 @@ export default function RegistroPage() {
                   ? 'Trabajos manuales y técnicos por oficio (ej: plomería, electricidad, mantenimiento).'
                   : 'Profesiones colegiadas o formales (ej: enfermería, arquitectura, abogacía).'}
               </p>
+              <div className="mt-3">
+                {g.id === 'oficios' ? (
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setIsOficiosPreviewOpen(true);
+                    }}
+                    className="inline-flex items-center text-sm font-semibold text-[#006F4B] hover:underline"
+                  >
+                    Ver categorías de oficios <ArrowRight className="ml-1 h-4 w-4" />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setIsProfesionesPreviewOpen(true);
+                    }}
+                    className="inline-flex items-center text-sm font-semibold text-[#006F4B] hover:underline"
+                  >
+                    Ver categorías de profesiones <ArrowRight className="ml-1 h-4 w-4" />
+                  </button>
+                )}
+              </div>
             </button>
           ))}
         </div>
         {errors.professionalGroup && <p className="text-red-600 text-sm mt-1">{errors.professionalGroup}</p>}
+
+        <Dialog open={isOficiosPreviewOpen} onOpenChange={setIsOficiosPreviewOpen}>
+          <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle className="text-2xl font-bold text-gray-900">
+                Categorías de Oficios
+              </DialogTitle>
+            </DialogHeader>
+            <div className="space-y-2 mt-4">
+              {AREAS_OFICIOS.map((area) => {
+                const isActive = selectedPreviewArea === area.slug;
+                const subcategories = SUBCATEGORIES_OFICIOS
+                  .filter((s) => s.areaSlug === area.slug)
+                  .map((s) => ({
+                    slug: s.slug,
+                    name: s.name,
+                  }));
+
+                const iconMap: Record<string, LucideIcon | null> = {
+                  "construccion-mantenimiento": Wrench,
+                  climatizacion: Snowflake,
+                  "servicios-electronicos": Bolt,
+                  automotores: Car,
+                  jardineria: TreePine,
+                };
+                const Icon = iconMap[area.slug] || Wrench;
+
+                return (
+                  <CategoryItem
+                    key={area.id}
+                    name={area.name}
+                    slug={area.slug}
+                    icon={Icon}
+                    isActive={isActive}
+                    subcategories={subcategories}
+                    onSelect={() => setSelectedPreviewArea(area.slug)}
+                    onSelectSubcategory={() => {}}
+                  />
+                );
+              })}
+            </div>
+            <div className="mt-6 rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-center">
+              <p className="text-sm font-medium text-emerald-900">
+                ¿No encontrás la categoría que se adapta a tu profesión?
+              </p>
+              <div className="mt-3">
+                <CategorySuggestionModal
+                  origin="registro_modal_oficios"
+                  triggerLabel="Sugerir categoría"
+                  triggerClassName="inline-flex items-center rounded-lg bg-[#006F4B] px-4 py-2 text-sm font-semibold text-white hover:bg-[#005a3d]"
+                />
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+
+        <Dialog open={isProfesionesPreviewOpen} onOpenChange={setIsProfesionesPreviewOpen}>
+          <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle className="text-2xl font-bold text-gray-900">
+                Categorías de Profesiones
+              </DialogTitle>
+            </DialogHeader>
+            <div className="space-y-2 mt-4">
+              {SUBCATEGORIES_PROFESIONES.map((profesion) => (
+                <div
+                  key={profesion.id}
+                  className="w-full flex items-center justify-between gap-3 px-4 py-3 text-sm font-medium rounded-lg text-left bg-gray-50 text-gray-700"
+                >
+                  <span className="truncate">{profesion.name}</span>
+                  <ArrowRight className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                </div>
+              ))}
+            </div>
+            <div className="mt-6 rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-center">
+              <p className="text-sm font-medium text-emerald-900">
+                ¿No encontrás la categoría que se adapta a tu profesión?
+              </p>
+              <div className="mt-3">
+                <CategorySuggestionModal
+                  origin="registro_modal_profesiones"
+                  triggerLabel="Sugerir categoría"
+                  triggerClassName="inline-flex items-center rounded-lg bg-[#006F4B] px-4 py-2 text-sm font-semibold text-white hover:bg-[#005a3d]"
+                />
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
       </div>
     </div>
   );

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -712,6 +712,8 @@ export default function DashboardPage() {
   const isVerified = me.verified;
   const needsCriminalRecordAlert =
     me.documentationRequired === true && me.criminalRecordPresent !== true;
+  const showVerificationPendingBanner =
+    !isVerified && me.status !== 'pending' && !needsCriminalRecordAlert;
  
   return (
     <div className="min-h-screen bg-gray-50">
@@ -772,7 +774,7 @@ export default function DashboardPage() {
           )}
 
             {/* Banner de estado de verificación (solo si no está pendiente) */}
-            {!isVerified && me.status !== 'pending' && (
+            {showVerificationPendingBanner && (
             <Card className="rounded-2xl border-2 border-orange-200 bg-gradient-to-r from-orange-50 to-yellow-50 mb-6">
               <CardContent className="p-6">
                 <div className="flex items-start space-x-4 ">
@@ -784,9 +786,8 @@ export default function DashboardPage() {
                       Tu perfil aún no ha sido verificado
                     </h3>
                     <p className="text-orange-800 text-sm leading-relaxed">
-                      Nuestro equipo está revisando tu información. Mientras tanto, puedes editar tu perfil 
-                      pero no aparecerás en los resultados de búsqueda hasta ser aprobado. 
-                      Te notificaremos por email cuando tu perfil esté verificado.
+                      Tu perfil está activo y visible, pero aún no tiene la insignia de verificación.
+                      La insignia se habilita cuando completes y apruebes la revisión de antecedentes.
                     </p>
                     
                   </div>
@@ -809,8 +810,19 @@ export default function DashboardPage() {
                       Te falta cargar el certificado de antecedentes penales
                     </p>
                     <p className="mt-1 text-sm text-amber-800">
-                      Tu perfil no podrá aparecer en la plataforma hasta que subas este documento.
-                      Puedes hacerlo ahora desde la configuración de tu perfil.
+                      Tu perfil puede seguir visible en la plataforma, pero sin insignia de verificación
+                      hasta que subas y se apruebe este documento.
+                    </p>
+                    <p className="mt-2 text-sm text-amber-900">
+                      Cómo obtenerlo:{' '}
+                      <a
+                        href="https://www.argentina.gob.ar/justicia/reincidencia/antecedentespenales"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline underline-offset-2"
+                      >
+                        https://www.argentina.gob.ar/justicia/reincidencia/antecedentespenales
+                      </a>
                     </p>
                   </div>
                 </div>

--- a/src/components/features/CategorySuggestionModal.tsx
+++ b/src/components/features/CategorySuggestionModal.tsx
@@ -125,11 +125,11 @@ export function CategorySuggestionModal({ origin, triggerClassName, triggerLabel
       <DialogContent className="sm:max-w-md max-h-[85vh] overflow-y-auto rounded-2xl">
         <DialogHeader>
           <DialogTitle className="text-xl font-rutan">
-            Sugerir una nueva categorÃ­a
+            Sugerir una nueva categoría
           </DialogTitle>
           <DialogDescription>
-            Contanos quÃ© categorÃ­a te gustarÃ­a que agreguemos a la plataforma. Esto nos
-            ayuda a priorizar los prÃ³ximos servicios.
+            Contanos qué categoría te gustaría que agreguemos a la plataforma. Esto nos
+            ayuda a priorizar los próximos servicios.
           </DialogDescription>
         </DialogHeader>
 
@@ -151,14 +151,14 @@ export function CategorySuggestionModal({ origin, triggerClassName, triggerLabel
               htmlFor="suggestedName"
               className="text-sm font-semibold text-gray-700"
             >
-              Nombre de la categorÃ­a
+              Nombre de la categoría
             </Label>
             <Input
               id="suggestedName"
               value={formData.suggestedName}
               onChange={(e) => handleChange("suggestedName", e.target.value)}
               className="mt-1 rounded-xl border-2 focus:ring-4 focus:ring-green-100 focus:border-[#006F4B] transition-all duration-200"
-              placeholder="Ej: Flete, Fisioterapia, DiseÃ±o grÃ¡fico..."
+              placeholder="Ej: Flete, Transporte, Fisioterapia, Diseño gráfico..."
               required
               maxLength={80}
             />
@@ -173,7 +173,7 @@ export function CategorySuggestionModal({ origin, triggerClassName, triggerLabel
               value={formData.details}
               onChange={(e) => handleChange("details", e.target.value)}
               className="mt-1 block w-full rounded-xl border-2 border-gray-200 px-3 py-2 text-sm focus:ring-4 focus:ring-green-100 focus:border-[#006F4B] transition-all duration-200 resize-y overflow-x-hidden"
-              placeholder="Contanos brevemente para quÃ© usarÃ­as esta categorÃ­a o quÃ© tipo de trabajos incluirÃ­a."
+              placeholder="Contanos brevemente para qué usarías esta categoría o qué tipo de trabajos incluiría."
               rows={4}
               maxLength={1000}
             />
@@ -192,7 +192,7 @@ export function CategorySuggestionModal({ origin, triggerClassName, triggerLabel
               value={formData.email}
               onChange={(e) => handleChange("email", e.target.value)}
               className="mt-1 rounded-xl border-2 focus:ring-4 focus:ring-green-100 focus:border-[#006F4B] transition-all duration-200"
-              placeholder="Para que podamos contactarte si necesitamos mÃ¡s informaciÃ³n"
+              placeholder="Para que podamos contactarte si necesitamos más información"
               required
               maxLength={120}
             />
@@ -206,8 +206,8 @@ export function CategorySuggestionModal({ origin, triggerClassName, triggerLabel
 
           {formState === "success" && (
             <p className="text-sm text-green-700 bg-green-50 border border-green-200 rounded-xl px-3 py-2">
-              Â¡Gracias! Registramos tu sugerencia y la tendremos en cuenta para las
-              prÃ³ximas categorÃ­as.
+              ¡Gracias! Registramos tu sugerencia y la tendremos en cuenta para las
+              próximas categorías.
             </p>
           )}
 

--- a/src/lib/server/professional-documentation.ts
+++ b/src/lib/server/professional-documentation.ts
@@ -40,6 +40,9 @@ export type SerializedLaborReference = {
 export type SerializedProfessionalDocumentation = {
   required: boolean;
   criminalRecordPresent: boolean;
+  criminalRecordStatus: "pending" | "approved" | "rejected" | null;
+  criminalRecordReviewedAt: string | null;
+  criminalRecordAdminNotes: string | null;
   hasLaborReferences: boolean;
   criminalRecord: SerializedDocumentationFile | null;
   laborReferences: SerializedLaborReference[];
@@ -52,6 +55,9 @@ export const professionalDocumentationArgs =
       professionalId: true,
       criminalRecordObjectKey: true,
       criminalRecordFileName: true,
+      criminalRecordStatus: true,
+      criminalRecordReviewedAt: true,
+      criminalRecordAdminNotes: true,
       laborReferences: {
         orderBy: { createdAt: "asc" },
         select: {
@@ -325,6 +331,9 @@ function serializeDocumentation(
   return {
     required: config.required,
     criminalRecordPresent: !!criminalRecord,
+    criminalRecordStatus: documentation?.criminalRecordStatus ?? null,
+    criminalRecordReviewedAt: documentation?.criminalRecordReviewedAt?.toISOString() ?? null,
+    criminalRecordAdminNotes: documentation?.criminalRecordAdminNotes ?? null,
     hasLaborReferences: laborReferences.length > 0,
     criminalRecord,
     laborReferences,
@@ -378,11 +387,15 @@ export async function upsertProfessionalDocumentation(
     update: {
       criminalRecordObjectKey: criminalRecord?.objectKey || null,
       criminalRecordFileName: criminalRecord?.fileName || null,
+      criminalRecordStatus: criminalRecord ? "pending" : null,
+      criminalRecordReviewedAt: null,
+      criminalRecordAdminNotes: null,
     },
     create: {
       professionalId,
       criminalRecordObjectKey: criminalRecord?.objectKey || null,
       criminalRecordFileName: criminalRecord?.fileName || null,
+      criminalRecordStatus: criminalRecord ? "pending" : null,
     },
     select: { id: true },
   });

--- a/src/lib/server/public-professional-visibility.ts
+++ b/src/lib/server/public-professional-visibility.ts
@@ -2,47 +2,17 @@ import { Prisma } from '@prisma/client';
 
 type ProfessionalVisibilityLike = {
   status: string | null | undefined;
-  verified: boolean | null | undefined;
-  requiresDocumentation?: boolean | null | undefined;
-  documentation?: {
-    criminalRecordObjectKey?: string | null | undefined;
-  } | null;
+  verified?: boolean | null | undefined;
 };
 
 export function getPublicProfessionalWhere(): Prisma.ProfessionalWhereInput {
   return {
     status: 'active',
-    verified: true,
-    OR: [
-      { requiresDocumentation: false },
-      {
-        AND: [
-          { requiresDocumentation: true },
-          {
-            documentation: {
-              is: {
-                criminalRecordObjectKey: {
-                  not: null,
-                },
-              },
-            },
-          },
-        ],
-      },
-    ],
   };
 }
 
 export function isProfessionalPubliclyVisible(
   professional: ProfessionalVisibilityLike
 ): boolean {
-  const meetsDocumentationRule =
-    professional.requiresDocumentation !== true ||
-    !!professional.documentation?.criminalRecordObjectKey;
-
-  return (
-    professional.status === 'active' &&
-    professional.verified === true &&
-    meetsDocumentationRule
-  );
+  return professional.status === 'active';
 }

--- a/src/lib/social-handles.ts
+++ b/src/lib/social-handles.ts
@@ -1,0 +1,67 @@
+export type SocialPlatform = "instagram" | "facebook" | "linkedin";
+
+function parseHandleFromUrl(rawValue: string, platform: SocialPlatform): string {
+  const normalizedInput = rawValue.startsWith("http://") || rawValue.startsWith("https://")
+    ? rawValue
+    : `https://${rawValue}`;
+
+  try {
+    const url = new URL(normalizedInput);
+    const host = url.hostname.toLowerCase();
+    const pathParts = url.pathname.split("/").filter(Boolean);
+
+    if (platform === "instagram" && host.includes("instagram.com")) {
+      return pathParts[0] || "";
+    }
+
+    if (platform === "facebook" && host.includes("facebook.com")) {
+      if (pathParts[0] === "profile.php") {
+        return url.searchParams.get("id") || "";
+      }
+      return pathParts[0] || "";
+    }
+
+    if (platform === "linkedin" && host.includes("linkedin.com")) {
+      if (pathParts[0] === "in" || pathParts[0] === "company") {
+        return pathParts[1] || "";
+      }
+      return pathParts[0] || "";
+    }
+  } catch {
+    return "";
+  }
+
+  return "";
+}
+
+export function normalizeSocialHandle(value: string, platform: SocialPlatform): string {
+  if (!value) return "";
+
+  const compact = value.trim().replace(/\s+/g, "");
+  if (!compact) return "";
+
+  let handle = compact;
+
+  const extracted = parseHandleFromUrl(compact, platform);
+  if (extracted) {
+    handle = extracted;
+  }
+
+  handle = handle.replace(/^@+/, "").replace(/[/?#].*$/, "").replace(/^\/+|\/+$/g, "");
+
+  return handle;
+}
+
+export function validateSocialHandle(value: string): string | null {
+  if (!value) return null;
+
+  if (/\s/.test(value)) {
+    return "El usuario no puede contener espacios.";
+  }
+
+  if (!/^[A-Za-z0-9._-]+$/.test(value)) {
+    return "Usa solo letras, números, punto, guión o guión bajo.";
+  }
+
+  return null;
+}

--- a/tests/integration/api/professionals.test.ts
+++ b/tests/integration/api/professionals.test.ts
@@ -77,7 +77,6 @@ describe('GET /api/professionals', () => {
     expect(hoisted.prismaMock.professional.count).toHaveBeenCalledWith({
       where: expect.objectContaining({
         status: 'active',
-        verified: true,
         professionalGroup: 'oficios',
       }),
     });
@@ -85,7 +84,6 @@ describe('GET /api/professionals', () => {
       expect.objectContaining({
         where: expect.objectContaining({
           status: 'active',
-          verified: true,
           professionalGroup: 'oficios',
         }),
       })

--- a/tests/integration/api/services.test.ts
+++ b/tests/integration/api/services.test.ts
@@ -33,7 +33,7 @@ describe('GET /api/services', () => {
     vi.clearAllMocks()
   })
 
-  it('retorna lista, totales y paginacion usando verificacion profesional', async () => {
+  it('retorna lista, totales y paginacion para profesionales activos', async () => {
     hoisted.prismaMock.service.count.mockResolvedValueOnce(2)
     hoisted.prismaMock.service.findMany.mockResolvedValueOnce([
       {
@@ -71,7 +71,6 @@ describe('GET /api/services', () => {
           available: true,
           professional: expect.objectContaining({
             status: 'active',
-            verified: true,
           }),
         }),
       })
@@ -82,7 +81,6 @@ describe('GET /api/services', () => {
           available: true,
           professional: expect.objectContaining({
             status: 'active',
-            verified: true,
           }),
         }),
       })

--- a/tests/unit/server/public-professional-visibility.test.ts
+++ b/tests/unit/server/public-professional-visibility.test.ts
@@ -5,49 +5,16 @@ import {
 } from '@/lib/server/public-professional-visibility';
 
 describe('public professional visibility', () => {
-  it('expone el filtro publico basado en estado activo, verificacion y documentacion requerida', () => {
+  it('expone el filtro publico basado solo en estado activo', () => {
     expect(getPublicProfessionalWhere()).toEqual({
       status: 'active',
-      verified: true,
-      OR: [
-        { requiresDocumentation: false },
-        {
-          AND: [
-            { requiresDocumentation: true },
-            {
-              documentation: {
-                is: {
-                  criminalRecordObjectKey: {
-                    not: null,
-                  },
-                },
-              },
-            },
-          ],
-        },
-      ],
     });
   });
 
-  it('considera publico solo un perfil activo, profesionalmente verificado y con documentacion obligatoria completa cuando aplica', () => {
+  it('considera publico cualquier perfil activo, aunque no este verificado', () => {
     expect(isProfessionalPubliclyVisible({ status: 'active', verified: true })).toBe(true);
-    expect(
-      isProfessionalPubliclyVisible({
-        status: 'active',
-        verified: true,
-        requiresDocumentation: true,
-        documentation: { criminalRecordObjectKey: 'private/doc.pdf' },
-      })
-    ).toBe(true);
-    expect(
-      isProfessionalPubliclyVisible({
-        status: 'active',
-        verified: true,
-        requiresDocumentation: true,
-        documentation: { criminalRecordObjectKey: null },
-      })
-    ).toBe(false);
-    expect(isProfessionalPubliclyVisible({ status: 'active', verified: false })).toBe(false);
+    expect(isProfessionalPubliclyVisible({ status: 'active', verified: false })).toBe(true);
     expect(isProfessionalPubliclyVisible({ status: 'pending', verified: true })).toBe(false);
+    expect(isProfessionalPubliclyVisible({ status: 'suspended', verified: true })).toBe(false);
   });
 });


### PR DESCRIPTION
Descripción
Este PR ajusta el flujo de aprobación para mejorar adhesión de profesionales sin perder la capa de confianza de verificación.

Qué cambia
Visibilidad pública de profesionales
Un profesional active ahora puede aparecer en búsquedas/listados públicos aunque no tenga antecedentes aprobados.
Se desacopla la visibilidad pública del estado de verificación documental.
Verificación (tilde azul) ligada a antecedentes aprobados
El badge de verificado pasa a depender de la revisión manual del certificado de antecedentes.
Aprobar certificaciones generales ya no marca automáticamente al profesional como verificado.
Nueva capa de revisión manual de antecedentes
Se agrega estado de revisión para antecedentes: pending | approved | rejected.
Al subir/re-subir antecedentes, el estado vuelve a pending.
Se agregan endpoints admin para:
listar antecedentes pendientes/revisados
aprobar/rechazar antecedentes de un profesional
Dashboard del profesional (plataforma)
Ajuste de banners/estado para no mostrar “perfil en revisión” cuando el perfil ya está activo.
Se mantiene mensaje específico para antecedentes cuando corresponde.
Se agrega link “Cómo obtenerlo” en el aviso de antecedentes.
Registro / onboarding (incluye social onboarding)
En el paso de selección “Oficios / Profesionales” se agrega previsualización de categorías en modal (sin selección en ese paso).
Se agrega widget de “No encontrás la categoría… Sugerir categoría” que abre el modal de contacto/sugerencia.
Se replica en flujo de completar perfil social.
Validación de redes sociales
Normalización y validación de instagram / facebook / linkedin para evitar entradas inválidas (ej: nombres con espacios).
Se aceptan handles o URLs, se extrae/normaliza el usuario y se muestran errores inline cuando no cumple formato.
Cambios técnicos (alto nivel)
DB/Prisma

ProfessionalDocumentation incorpora campos de revisión de antecedentes (status, reviewedAt, adminNotes).
Nueva migración para enum + columnas.
API Admin

Nuevas rutas para review de antecedentes.
Ajustes en serialización/upsert de documentación para soportar estado de revisión.
Ajuste en aprobación de certificaciones para no auto-verificar.
Frontend

Dashboard profesional: mensajes y link de ayuda de antecedentes.
Registro y completar perfil: modales de categorías + sugerencia.
Validaciones sociales reutilizables.
Impacto de negocio esperado
Menor fricción de alta inicial (más profesionales visibles).
Conserva señal de confianza: solo perfiles con antecedentes aprobados muestran tilde azul.
Proceso sigue siendo manual (control operativo), pero con capa explícita de revisión documental.
Verificación realizada
Tests enfocados ejecutados:
tests/unit/server/public-professional-visibility.test.ts
tests/integration/api/professionals.test.ts
tests/integration/api/services.test.ts
Typecheck del proyecto ejecutado.
Seguridad de datos en producción
Este cambio no implica pérdida de datos en producción:

En CI/CD se usa prisma migrate deploy.
La migración agregada es aditiva (enum + columnas), sin DROP/TRUNCATE/reset.